### PR TITLE
algebra: scalar, stark_curve: stark point transcript serialization & hash to scalar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ digest = "0.10"
 num-bigint = "0.4"
 rand = "0.8"
 sha3 = { version = "0.10" }
+tiny-keccak = { version = "2.0.2", features=["keccak"] }
 
 # == Networking + Messaging == # 
 rcgen = "0.9"

--- a/src/algebra/scalar.rs
+++ b/src/algebra/scalar.rs
@@ -42,8 +42,7 @@ pub struct StarknetFrConfig;
 /// Note that this is not the field that the curve is defined over, but field of integers modulo
 /// the order of the curve's group, see [here](https://crypto.stackexchange.com/questions/98124/is-the-stark-curve-a-safecurve)
 /// for more information
-// pub(crate) type ScalarInner = Fp256<MontBackend<StarknetFrConfig, 4>>;
-pub(crate) type ScalarInner = StarknetBaseFelt;
+pub(crate) type ScalarInner = Fp256<MontBackend<StarknetFrConfig, 4>>;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 /// A wrapper around the inner scalar that allows us to implement foreign traits for the `Scalar`
 pub struct Scalar(pub(crate) ScalarInner);

--- a/src/algebra/scalar.rs
+++ b/src/algebra/scalar.rs
@@ -42,7 +42,8 @@ pub struct StarknetFrConfig;
 /// Note that this is not the field that the curve is defined over, but field of integers modulo
 /// the order of the curve's group, see [here](https://crypto.stackexchange.com/questions/98124/is-the-stark-curve-a-safecurve)
 /// for more information
-pub(crate) type ScalarInner = Fp256<MontBackend<StarknetFrConfig, 4>>;
+// pub(crate) type ScalarInner = Fp256<MontBackend<StarknetFrConfig, 4>>;
+pub(crate) type ScalarInner = StarknetBaseFelt;
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 /// A wrapper around the inner scalar that allows us to implement foreign traits for the `Scalar`
 pub struct Scalar(pub(crate) ScalarInner);

--- a/src/algebra/stark_curve.rs
+++ b/src/algebra/stark_curve.rs
@@ -122,6 +122,18 @@ impl StarkPoint {
         out
     }
 
+    /// Serialize this point to a byte buffer in a way that is consistent
+    /// with the Cairo serialization of EC points, such that it can be absorbed
+    /// into a Fiat-Shamir transcript
+    pub fn to_transcript_bytes(&self) -> Vec<u8> {
+        let mut out: Vec<u8> = Vec::with_capacity(size_of::<StarkPoint>());
+        self.0
+            .serialize_uncompressed(&mut out)
+            .expect("Failed to serialize point");
+
+        out
+    }
+
     /// Deserialize a point from a byte buffer
     pub fn from_bytes(bytes: &[u8]) -> Result<StarkPoint, SerializationError> {
         let point = StarkPointInner::deserialize_compressed(bytes)?;


### PR DESCRIPTION
This PR introduces a method `to_transcript_bytes` on the `StarkPoint` struct which serializes a `StarkPoint` in the exact same way as is done contract-side in Cairo. This is necessary to have transcript consistency between the prover and the verifier.

Additionally, this adds a helper `from_uniform_bytes` on the `Scalar` struct which, given a 32-byte hash output, converts it to a `Scalar` in the exact same way as is done in Cairo. This is used in `mpc-bulletproof` when drawing challenge scalars out of the transcript and when sampling generators.