### PR TITLE
network-sender: Split read and write streams into separate `Tokio` tasks

### DIFF
--- a/integration/main.rs
+++ b/integration/main.rs
@@ -4,9 +4,10 @@ use clap::Parser;
 use colored::Colorize;
 use dns_lookup::lookup_host;
 use env_logger::Builder;
+use futures::{SinkExt, StreamExt};
 use helpers::PartyIDBeaverSource;
 use mpc_stark::{
-    network::{MpcNetwork, NetworkOutbound, NetworkPayload, QuicTwoPartyNet},
+    network::{NetworkOutbound, NetworkPayload, QuicTwoPartyNet},
     MpcFabric, PARTY0,
 };
 use tokio::runtime::{Builder as RuntimeBuilder, Handle};
@@ -116,13 +117,13 @@ fn main() {
         // Send a byte to give the connection time to establish
         if args.party == 0 {
             Handle::current()
-                .block_on(net.send_message(NetworkOutbound {
+                .block_on(net.send(NetworkOutbound {
                     result_id: 1,
                     payload: NetworkPayload::Bytes(vec![1u8]),
                 }))
                 .unwrap();
         } else {
-            let _recv_bytes = Handle::current().block_on(net.receive_message()).unwrap();
+            let _recv_bytes = Handle::current().block_on(net.next()).unwrap();
         }
 
         let beaver_source = PartyIDBeaverSource::new(args.party);

--- a/src/algebra/authenticated_scalar.rs
+++ b/src/algebra/authenticated_scalar.rs
@@ -658,7 +658,7 @@ impl Sub<&ScalarResult> for &AuthenticatedScalarResult {
         let new_modifier = &self.public_modifier + rhs;
         AuthenticatedScalarResult {
             share: new_share,
-            mac: -&self.mac,
+            mac: self.mac.clone(),
             public_modifier: new_modifier,
         }
     }

--- a/src/fabric/executor.rs
+++ b/src/fabric/executor.rs
@@ -90,7 +90,7 @@ impl Executor {
                         log::debug!("executor shutting down");
 
                         // In benchmarks print the average queue length
-                        #[cfg(all(feature = "benchmarks", feature = "debug_info"))]
+                        #[cfg(feature = "debug_info")]
                         {
                             println!("average queue length: {}", self.avg_queue_length());
                         }
@@ -100,7 +100,7 @@ impl Executor {
                 }
             }
 
-            #[cfg(feature = "benchmarks")]
+            #[cfg(feature = "debug_info")]
             {
                 self.summed_queue_length += self.job_queue.len() as u64;
                 self.queue_length_sample_count += 1;
@@ -109,7 +109,7 @@ impl Executor {
     }
 
     /// Returns the average queue length over the execution of the executor
-    #[cfg(feature = "benchmarks")]
+    #[cfg(feature = "debug_info")]
     pub fn avg_queue_length(&self) -> f64 {
         (self.summed_queue_length as f64) / (self.queue_length_sample_count as f64)
     }

--- a/src/fabric/executor.rs
+++ b/src/fabric/executor.rs
@@ -27,10 +27,10 @@ pub struct Executor {
     /// The underlying fabric that the executor is a part of
     fabric: FabricInner,
     /// The total sampled queue length of the executor's work queue
-    #[cfg(feature = "benchmarks")]
+    #[cfg(feature = "debug_info")]
     summed_queue_length: u64,
     /// The number of samples taken of the executor's work queue length
-    #[cfg(feature = "benchmarks")]
+    #[cfg(feature = "debug_info")]
     queue_length_sample_count: usize,
 }
 
@@ -56,7 +56,7 @@ impl Executor {
         job_queue: Arc<SegQueue<ExecutorMessage>>,
         fabric: FabricInner,
     ) -> Self {
-        #[cfg(feature = "benchmarks")]
+        #[cfg(feature = "debug_info")]
         {
             Self {
                 job_queue,
@@ -68,7 +68,7 @@ impl Executor {
             }
         }
 
-        #[cfg(not(feature = "benchmarks"))]
+        #[cfg(not(feature = "debug_info"))]
         {
             Self {
                 job_queue,

--- a/src/network/stream_buffer.rs
+++ b/src/network/stream_buffer.rs
@@ -1,0 +1,61 @@
+//! Defines an `std::io::Cursor` like buffer that tracks a cursor within a buffer that
+//! is incrementally consumed. We use this to allow partial fills across cancelled
+//! futures.
+//!
+//! This will be replaced when the more convenient `std::io::Cursor` is stabilized.
+
+/// A wrapper around a raw `&[u8]` buffer that tracks a cursor within the buffer
+/// to allow partial fills across cancelled futures
+///
+/// Similar to `tokio::io::ReadBuf` but takes ownership of the underlying buffer to
+/// avoid coloring interfaces with lifetime parameters
+///
+/// TODO: Replace this with `std::io::Cursor` once it is stabilized
+#[derive(Debug)]
+pub struct BufferWithCursor {
+    /// The underlying buffer
+    buffer: Vec<u8>,
+    /// The current cursor position
+    cursor: usize,
+}
+
+impl BufferWithCursor {
+    /// Create a new buffer with a cursor at the start of the buffer
+    pub fn new(buf: Vec<u8>) -> Self {
+        assert_eq!(
+            buf.len(),
+            buf.capacity(),
+            "buffer must be fully initialized"
+        );
+
+        Self {
+            buffer: buf,
+            cursor: 0,
+        }
+    }
+
+    /// The number of bytes remaining in the buffer
+    pub fn remaining(&self) -> usize {
+        self.buffer.capacity() - self.cursor
+    }
+
+    /// Whether the buffer is full
+    pub fn is_depleted(&self) -> bool {
+        self.remaining() == 0
+    }
+
+    /// Get a mutable reference to the empty section of the underlying buffer
+    pub fn get_remaining(&mut self) -> &mut [u8] {
+        &mut self.buffer[self.cursor..]
+    }
+
+    /// Advance the cursor by `n` bytes
+    pub fn advance_cursor(&mut self, n: usize) {
+        self.cursor += n
+    }
+
+    /// Take ownership of the underlying buffer
+    pub fn into_vec(self) -> Vec<u8> {
+        self.buffer
+    }
+}


### PR DESCRIPTION
### Background
On large circuits (i.e. some of the integration tests in `renegade`), the MPC execution stalls after some time. After some debugging, it was found that:
1. The `Executor` enqueues outbound network requests much faster than inbound requests arrive.
2. The [`tokio::select`](https://github.com/renegade-fi/mpc-stark/blob/bffa18c1f9f1bd8daba97e35f3f76b023c0f0561/src/fabric/network_sender.rs#L55) driving the `NetworkSender` event loop then starves the receive path and continues sending
3. The QUIC outbound buffers fill up and/or are rate limited by congestion control. This blocks the send path on both sides (as no receives are happening), thereby blocking the main event loop of the `NetworkSender`

### Purpose
This PR refactors the implementation of the `MpcNetwork` trait to implement both `Stream<Item = NetworkOutbound>` and `Sink<NetworkOutbound>`. This allows the event loop to split the two streams using `StreamExt::split` and the read and write data paths in their own tokio tasks.

With each of the read and write streams in its own event loop; neither is starved and the buffers do not bloat.

### Testing
- Unit and integration tests pass
- Tested large circuits in the `renegade` repo