### PR TITLE
meta: Bump version to `v0.2.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-stark"
-version = "0.1.0"
+version = "0.2.0"
 description = "Malicious-secure SPDZ style two party secure computation"
 keywords = ["mpc", "crypto", "cryptography"]
 homepage = "https://renegade.fi"


### PR DESCRIPTION
### Purpose
This PR bumps the version of `mpc-stark` to `v0.2.0`, releasing batch functionality and throughput optimizations.