### PR TITLE
benches: msm-throughput, mul-throughput: Add `mul` and `msm` benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,11 @@ name = "mul_throughput"
 harness = false
 required-features = ["benchmarks", "test_helpers"]
 
+[[bench]]
+name = "msm_throughput"
+harness = false
+required-features = ["benchmarks", "test_helpers"]
+
 [dependencies]
 # == Concurrency == #
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,8 @@ harness = false
 required-features = ["test_helpers"]
 
 [profile.bench]
-opt-level = 0
+opt-level = 3
+lto = true
 debug = true
 
 [[bench]]
@@ -43,6 +44,11 @@ required-features = ["benchmarks", "test_helpers"]
 name = "growable_buffer"
 harness = false
 required-features = ["benchmarks"]
+
+[[bench]]
+name = "mul_throughput"
+harness = false
+required-features = ["benchmarks", "test_helpers"]
 
 [dependencies]
 # == Concurrency == #

--- a/benches/msm_throughput.rs
+++ b/benches/msm_throughput.rs
@@ -1,0 +1,61 @@
+//! Benchmarks multiscalar multiplication throughput as executed via the `Executor`
+
+use std::time::{Duration, Instant};
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use itertools::Itertools;
+use mpc_stark::{
+    algebra::authenticated_stark_point::AuthenticatedStarkPointResult,
+    test_helpers::execute_mock_mpc,
+};
+use tokio::runtime::Builder as RuntimeBuilder;
+
+/// Measure the throughput and latency of a variable-sized MSM
+pub fn bench_msm_throughput(c: &mut Criterion) {
+    let runtime = RuntimeBuilder::new_multi_thread()
+        .worker_threads(3)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let mut group = c.benchmark_group("msm-throughput");
+    for circuit_size in [100, 1000, 10000].into_iter() {
+        group.throughput(Throughput::Elements(circuit_size as u64));
+        group.bench_function(BenchmarkId::from_parameter(circuit_size), |b| {
+            let mut b = b.to_async(&runtime);
+            b.iter_custom(|n_iters| async move {
+                let mut total_time = Duration::from_millis(0);
+                for _ in 0..n_iters {
+                    let (elapsed1, elapsed2) = execute_mock_mpc(|fabric| async move {
+                        let scalars = (0..circuit_size)
+                            .map(|_| fabric.one_authenticated())
+                            .collect_vec();
+                        let points = (0..circuit_size)
+                            .map(|_| fabric.curve_identity_authenticated())
+                            .collect_vec();
+
+                        let start_time = Instant::now();
+
+                        let res = AuthenticatedStarkPointResult::msm(&scalars, &points);
+                        black_box(res.open().await);
+
+                        start_time.elapsed()
+                    })
+                    .await;
+
+                    // Add the maximum amount of time for either party to finish to the total
+                    total_time += Duration::max(elapsed1, elapsed2);
+                }
+
+                total_time
+            })
+        });
+    }
+}
+
+criterion_group!(
+    name = msm_throughput;
+    config = Criterion::default().sample_size(10);
+    targets = bench_msm_throughput
+);
+criterion_main!(msm_throughput);

--- a/benches/mul_throughput.rs
+++ b/benches/mul_throughput.rs
@@ -1,0 +1,53 @@
+//! Benchmarks for multiplication gate throughput
+
+use std::time::{Duration, Instant};
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use mpc_stark::{test_helpers::execute_mock_mpc, PARTY0};
+use tokio::runtime::Builder as RuntimeBuilder;
+
+/// Measure the throughput and latency of a set of sequential multiplication gates
+pub fn bench_mul_throughput(c: &mut Criterion) {
+    let runtime = RuntimeBuilder::new_multi_thread()
+        .worker_threads(3)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let mut group = c.benchmark_group("mul-throughput");
+    for circuit_size in [100, 1000, 10000].into_iter() {
+        group.throughput(Throughput::Elements(circuit_size as u64));
+        group.bench_function(BenchmarkId::from_parameter(circuit_size), |b| {
+            let mut b = b.to_async(&runtime);
+            b.iter_custom(|n_iters| async move {
+                let mut total_time = Duration::from_millis(0);
+                for _ in 0..n_iters {
+                    let (elapsed1, elapsed2) = execute_mock_mpc(|fabric| async move {
+                        let mut res = fabric.share_scalar(1, PARTY0);
+
+                        let start_time = Instant::now();
+                        for _ in 0..circuit_size {
+                            res = &res * &res;
+                        }
+
+                        black_box(res.open().await);
+                        start_time.elapsed()
+                    })
+                    .await;
+
+                    // Add the maximum amount of time for either party to finish to the total
+                    total_time += Duration::max(elapsed1, elapsed2);
+                }
+
+                total_time
+            })
+        });
+    }
+}
+
+criterion_group!(
+    name = mul_throughput;
+    config = Criterion::default().sample_size(10);
+    targets = bench_mul_throughput
+);
+criterion_main!(mul_throughput);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,9 @@ pub type SharedNetwork<N: MpcNetwork + Send> = Rc<RefCell<N>>;
 #[allow(type_alias_bounds)]
 pub type BeaverSource<S: SharedValueSource> = Rc<RefCell<S>>;
 
-#[cfg(test)]
-pub(crate) mod test_helpers {
+#[cfg(any(test, feature = "test_helpers"))]
+pub mod test_helpers {
+    //! Defines test helpers for use in unit and integration tests, as well as benchmarks
     use futures::Future;
 
     use crate::{

--- a/src/network.rs
+++ b/src/network.rs
@@ -6,7 +6,7 @@ mod mock;
 mod stream_buffer;
 
 use futures::{Future, Sink, Stream};
-#[cfg(any(feature = "test_helpers", test))]
+#[cfg(any(feature = "test_helpers", feature = "benchmarks", test))]
 pub use mock::{MockNetwork, NoRecvNetwork, UnboundedDuplexStream};
 
 use async_trait::async_trait;


### PR DESCRIPTION
### Purpose
This PR adds two benchmarks for large multiplication circuits and large multiscalar multiplications. These are the bottlenecks of the downstream use in `mpc-bulletproof` so these benchmarks serve as good optimization targets.

### Testing
- Unit and integration tests pass
- Ran benchmarks