### PR TITLE
fabric: network-sender: Change outbound queue to use kanal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ required-features = ["benchmarks", "test_helpers"]
 async-trait = "0.1"
 crossbeam = "0.8"
 futures = "0.3"
+kanal = "0.1.0-pre8"
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
 
 # == Arithemtic + Crypto == #

--- a/benches/growable_buffer.rs
+++ b/benches/growable_buffer.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use mpc_stark::{algebra::scalar::Scalar, buffer::GrowableBuffer};
 
 // --------------
@@ -17,7 +17,7 @@ pub fn buffer_read__sequential(c: &mut Criterion) {
         group.bench_function(BenchmarkId::from_parameter(buffer_size), |b| {
             b.iter(|| {
                 for i in 0..buffer_size {
-                    buffer.get(i);
+                    black_box(buffer.get(i));
                 }
             })
         });


### PR DESCRIPTION
### Purpose
This PR changes the `NetworkSender`'s outbound queue to use `kanal` which is generally faster than `tokio::sync::mpsc`.

### Testing
- Unit and integration tests pass
- Ran benchmarks, saw 10-20% improvement in network heavy throughput