### PR TITLE
algebra: stark-curve: Use serial MSM below 10 elements

### DIFF
--- a/benches/native_msm.rs
+++ b/benches/native_msm.rs
@@ -8,12 +8,15 @@ use mpc_stark::{
 };
 use rand::thread_rng;
 
+/// The maximum power of two to scale the MSM benchmark to
+const MAX_POWER_OF_TWO: usize = 16; // 2^16 = 65536
+
 /// Measures the raw throughput of a native MSM
 pub fn bench_native_msm(c: &mut Criterion) {
     let mut rng = thread_rng();
 
     let mut group = c.benchmark_group("native_msm");
-    for n_elems in [100, 1_000, 10_000, 100_000].into_iter() {
+    for n_elems in (0..MAX_POWER_OF_TWO).map(|i| 1 << i) {
         group.throughput(Throughput::Elements(n_elems));
         group.bench_function(BenchmarkId::from_parameter(n_elems), |b| {
             let scalars = (0..n_elems).map(|_| Scalar::random(&mut rng)).collect_vec();


### PR DESCRIPTION
### Purpose
This PR changes the implementation of `StarkPoint::msm` to use a serial multiscalar multiplication below 10 elements. This avoid the overhead of spinning up a `rayon` thread pool which `ark-ec` does under the hood for its MSM implementation.

This PR also refactors each individual MSM implementation to call down to `StarkPoint::msm` in some way or another, such that this optimization is inherited.

### Testing
- Unit and integration tests pass