### PR TITLE
fabric: executor: Track circuit depth and operation counts in `ExecutorStats`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,11 @@ required-features = ["benchmarks"]
 name = "native_msm"
 harness = false
 
+[[bench]]
+name = "test_stats"
+harness = false
+required-features = ["benchmarks", "stats", "test_helpers"]
+
 [dependencies]
 # == Concurrency == #
 async-trait = "0.1"

--- a/benches/test_stats.rs
+++ b/benches/test_stats.rs
@@ -1,0 +1,29 @@
+//! A simple benchmark for testing that stats collection is properly working
+
+use mpc_stark::{algebra::scalar::Scalar, test_helpers::execute_mock_mpc, PARTY0, PARTY1};
+use rand::{distributions::uniform::SampleRange, thread_rng};
+
+#[tokio::main]
+async fn main() {
+    // Run the following circuit with the `stats` feature enabled and
+    // the stats will be dumped at the end of execution
+    let mut rng = thread_rng();
+    let depth = (0usize..=1000).sample_single(&mut rng);
+
+    let value1 = Scalar::random(&mut rng);
+    let value2 = Scalar::random(&mut rng);
+
+    println!("Sampled depth: {depth}");
+    execute_mock_mpc(|fabric| async move {
+        let party0_value = fabric.share_scalar(value1, PARTY0);
+        let party1_value = fabric.share_scalar(value2, PARTY1);
+
+        let mut res = fabric.zero_authenticated();
+        for _ in 0..depth {
+            res = &party0_value + &res * &party1_value;
+        }
+
+        res.open().await
+    })
+    .await;
+}

--- a/src/fabric/network_sender.rs
+++ b/src/fabric/network_sender.rs
@@ -131,7 +131,7 @@ impl<N: MpcNetwork + 'static> NetworkSender<N> {
 
         // Log the stats after execution finishes
         #[cfg(feature = "stats")]
-        println!("network stats: {:#?}", stats);
+        println!("Network stats: {:#?}", stats);
     }
 
     /// The read loop for the network, reads messages from the network and re-enqueues them


### PR DESCRIPTION
### Purpose
This PR adds `ExecutorStats` to the `Executor` which are dumped to `stdout` on termination. These stats track:
- The number of operations executed
- The number of network operations executed
- The average queue length of the executor during execution
- The depth of the circuit, i.e. the largest depth of any result

### Testing
- Unit and integration tests pass
- Tested the circuit depth via the benchmark in this PR and verified that its output was expected
- Ran other benchmarks, verified that the telemetry code was compiled out when `not(feature = "stats")`; benchmarks were unaffected