### PR TITLE
release: Bump version to `v0.2.2`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-stark"
-version = "0.2.1"
+version = "0.2.2"
 description = "Malicious-secure SPDZ style two party secure computation"
 keywords = ["mpc", "crypto", "cryptography"]
 homepage = "https://renegade.fi"


### PR DESCRIPTION
### Purpose
This PR bumps the library version to `v0.2.2` to include the statistics collection changes of #15 #16 