### PR TITLE
algebra: stark-curve: Add `from_affine_coords` method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mpc-stark"
-version = "0.2.2"
+version = "0.2.4"
 description = "Malicious-secure SPDZ style two party secure computation"
 keywords = ["mpc", "crypto", "cryptography"]
 homepage = "https://renegade.fi"

--- a/src/algebra/stark_curve.rs
+++ b/src/algebra/stark_curve.rs
@@ -138,7 +138,6 @@ impl StarkPoint {
             y,
             infinity: false,
         };
-        assert!(aff.is_on_curve(), "invalid affine coordinates");
 
         Self(aff.into())
     }


### PR DESCRIPTION
### Purpose
This PR adds a `from_affine_coords` method that allows the caller to construct a `StarkPoint` from its affine component representation. This is useful for deserialization implementations on the `StarkPoint` from non-byte formats (e.g. Starknet calldata).

This PR also bumps the patch version of this library to include this method in the public interface.

### Testing
- Unit and integration tests pass
- Tested the projective -> affine coordinates -> projective point code path in unit