### PR TITLE
network, fabric, algebra: Make entire crate generic over curve choice

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 [features]
 benchmarks = []
 stats = ["benchmarks"]
-test_helpers = []
+test_helpers = ["ark-curve25519"]
 
 [[test]]
 name = "integration"
@@ -73,6 +73,7 @@ kanal = "0.1.0-pre8"
 tokio = { version = "1.12", features = ["macros", "rt-multi-thread"] }
 
 # == Arithemtic + Crypto == #
+ark-curve25519 = { version = "0.4", optional = true }
 ark-ec = { version = "0.4", features = ["parallel"] }
 ark-ff = "0.4"
 ark-serialize = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ ark-curve25519 = { version = "0.4", optional = true }
 ark-ec = { version = "0.4", features = ["parallel"] }
 ark-ff = "0.4"
 ark-serialize = "0.4"
+ark-std = "0.4"
 digest = "0.10"
 num-bigint = "0.4"
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "mpc-stark"
-version = "0.2.4"
+name = "ark-mpc"
+version = "0.1.0"
 description = "Malicious-secure SPDZ style two party secure computation"
 keywords = ["mpc", "crypto", "cryptography"]
 homepage = "https://renegade.fi"
 authors = ["Joey Kraut <joey@renegade.fi>"]
 edition = "2021"
 readme = "README.md"
-repository = "https://github.com/renegade-fi/mpc-ristretto"
+repository = "https://github.com/renegade-fi/ark-mpc"
 license = "MIT OR Apache-2.0"
 
 [lib]
-name = "mpc_stark"
+name = "ark_mpc"
 path = "src/lib.rs"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,27 +1,30 @@
-# MPC-Stark
+# `ark-mpc`
 <div>
   <img
-    src="https://github.com/renegade-fi/mpc-stark/actions/workflows/test.yml/badge.svg"
+    src="https://github.com/renegade-fi/ark-mpc/actions/workflows/test.yml/badge.svg"
   />
   <img
-    src="https://github.com/renegade-fi/mpc-stark/actions/workflows/clippy.yml/badge.svg"
+    src="https://github.com/renegade-fi/ark-mpc/actions/workflows/clippy.yml/badge.svg"
   />
   <img
-    src="https://github.com/renegade-fi/mpc-stark/actions/workflows/rustfmt.yml/badge.svg"
+    src="https://github.com/renegade-fi/ark-mpc/actions/workflows/rustfmt.yml/badge.svg"
   />
   <img
-    src="https://img.shields.io/crates/v/mpc-stark"
+    src="https://img.shields.io/crates/v/ark-mpc"
   />
 </div>
 
 ## Example
-`mpc-stark` provides a malicious secure [SPDZ](https://eprint.iacr.org/2011/535.pdf) style framework for two party secure computation. The circuit is constructed on the fly, by overloading arithmetic operators of MPC types, see the example below in which each of the parties shares a value and together they compute the product:
+`ark-mpc` provides a malicious secure [SPDZ](https://eprint.iacr.org/2011/535.pdf) style framework for two party secure computation. The circuit is constructed on the fly, by overloading arithmetic operators of MPC types, see the example below in which each of the parties shares a value and together they compute the product:
 ```rust
-use mpc_stark::{
+use ark_mpc::{
     algebra::scalar::Scalar, beaver::SharedValueSource, network::QuicTwoPartyNet, MpcFabric,
     PARTY0, PARTY1,
 };
+use ark_curve25519::EdwardsProjective as Curve25519Projective;
 use rand::thread_rng;
+
+type Curve = Curve25519Projective;
 
 #[tokio::main]
 async fn main() {
@@ -34,7 +37,7 @@ async fn main() {
 
     // MPC circuit
     let mut rng = thread_rng();
-    let my_val = Scalar::random(&mut rng);
+    let my_val = Scalar::<Curve>::random(&mut rng);
     let fabric = MpcFabric::new(network, beaver);
 
     let a = fabric.share_scalar(my_val, PARTY0 /* sender */); // party0 value
@@ -50,7 +53,7 @@ async fn main() {
 ## Tests
 Unit tests for isolated parts of the library are available via
 ```bash
-cargo test --lib
+cargo test --lib --all-features
 ```
 
 The bulk of this library's testing is best done with real communication; and so most of the tests are integration tests. The integration tests can be run as

--- a/benches/circuit_msm_throughput.rs
+++ b/benches/circuit_msm_throughput.rs
@@ -2,11 +2,11 @@
 
 use std::time::{Duration, Instant};
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::authenticated_curve::AuthenticatedPointResult, test_helpers::execute_mock_mpc,
 };
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use itertools::Itertools;
 use tokio::runtime::Builder as RuntimeBuilder;
 
 /// Measure the throughput and latency of a variable-sized MSM

--- a/benches/circuit_msm_throughput.rs
+++ b/benches/circuit_msm_throughput.rs
@@ -5,8 +5,7 @@ use std::time::{Duration, Instant};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use itertools::Itertools;
 use mpc_stark::{
-    algebra::authenticated_stark_point::AuthenticatedStarkPointResult,
-    test_helpers::execute_mock_mpc,
+    algebra::authenticated_curve::AuthenticatedPointResult, test_helpers::execute_mock_mpc,
 };
 use tokio::runtime::Builder as RuntimeBuilder;
 
@@ -36,7 +35,7 @@ pub fn bench_msm_throughput(c: &mut Criterion) {
 
                         let start_time = Instant::now();
 
-                        let res = AuthenticatedStarkPointResult::msm(&scalars, &points);
+                        let res = AuthenticatedPointResult::msm(&scalars, &points);
                         black_box(res.open().await);
 
                         start_time.elapsed()

--- a/benches/circuit_mul_throughput.rs
+++ b/benches/circuit_mul_throughput.rs
@@ -23,7 +23,7 @@ pub fn bench_mul_throughput(c: &mut Criterion) {
                 let mut total_time = Duration::from_millis(0);
                 for _ in 0..n_iters {
                     let (elapsed1, elapsed2) = execute_mock_mpc(|fabric| async move {
-                        let mut res = fabric.share_scalar(1, PARTY0);
+                        let mut res = fabric.share_scalar(1u8, PARTY0);
 
                         let start_time = Instant::now();
                         for _ in 0..circuit_size {

--- a/benches/circuit_mul_throughput.rs
+++ b/benches/circuit_mul_throughput.rs
@@ -2,8 +2,8 @@
 
 use std::time::{Duration, Instant};
 
+use ark_mpc::{test_helpers::execute_mock_mpc, PARTY0};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use mpc_stark::{test_helpers::execute_mock_mpc, PARTY0};
 use tokio::runtime::Builder as RuntimeBuilder;
 
 /// Measure the throughput and latency of a set of sequential multiplication gates

--- a/benches/gate_throughput.rs
+++ b/benches/gate_throughput.rs
@@ -6,7 +6,8 @@ use criterion::{
     Criterion, Throughput,
 };
 use mpc_stark::{
-    algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork, MpcFabric, PARTY0,
+    algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork,
+    test_helpers::TestCurve, MpcFabric, PARTY0,
 };
 use rand::{rngs::OsRng, thread_rng};
 use tokio::runtime::Builder as RuntimeBuilder;
@@ -41,7 +42,7 @@ pub fn config() -> Criterion {
 }
 
 /// Create a mock fabric for testing
-pub fn mock_fabric(size_hint: usize) -> MpcFabric {
+pub fn mock_fabric(size_hint: usize) -> MpcFabric<TestCurve> {
     let network = NoRecvNetwork::default();
     let beaver_source = PartyIDBeaverSource::new(PARTY0);
     MpcFabric::new_with_size_hint(size_hint, network, beaver_source)
@@ -54,7 +55,7 @@ pub fn mock_fabric(size_hint: usize) -> MpcFabric {
 /// Measures the raw throughput of scalar addition
 pub fn scalar_addition(c: &mut Criterion) {
     let mut rng = thread_rng();
-    let mut res = Scalar::random(&mut rng);
+    let mut res = Scalar::<TestCurve>::random(&mut rng);
 
     let mut group = c.benchmark_group("raw_scalar_addition");
 

--- a/benches/gate_throughput.rs
+++ b/benches/gate_throughput.rs
@@ -1,13 +1,13 @@
 use std::{path::Path, sync::Mutex};
 
+use ark_mpc::{
+    algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork,
+    test_helpers::TestCurve, MpcFabric, PARTY0,
+};
 use cpuprofiler::{Profiler as CpuProfiler, PROFILER};
 use criterion::{
     criterion_group, criterion_main, profiler::Profiler as CriterionProfiler, BenchmarkId,
     Criterion, Throughput,
-};
-use mpc_stark::{
-    algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork,
-    test_helpers::TestCurve, MpcFabric, PARTY0,
 };
 use rand::{rngs::OsRng, thread_rng};
 use tokio::runtime::Builder as RuntimeBuilder;

--- a/benches/gate_throughput_traced.rs
+++ b/benches/gate_throughput_traced.rs
@@ -3,13 +3,13 @@
 
 use std::time::Instant;
 
-use clap::Parser;
-use cpuprofiler::PROFILER;
-use gperftools::HEAP_PROFILER;
-use mpc_stark::{
+use ark_mpc::{
     algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork,
     test_helpers::TestCurve, MpcFabric, PARTY0,
 };
+use clap::Parser;
+use cpuprofiler::PROFILER;
+use gperftools::HEAP_PROFILER;
 use rand::thread_rng;
 
 // -----------

--- a/benches/gate_throughput_traced.rs
+++ b/benches/gate_throughput_traced.rs
@@ -7,7 +7,8 @@ use clap::Parser;
 use cpuprofiler::PROFILER;
 use gperftools::HEAP_PROFILER;
 use mpc_stark::{
-    algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork, MpcFabric, PARTY0,
+    algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork,
+    test_helpers::TestCurve, MpcFabric, PARTY0,
 };
 use rand::thread_rng;
 
@@ -19,7 +20,7 @@ use rand::thread_rng;
 const NUM_GATES: usize = 10_000_000;
 
 /// Create a mock fabric for testing
-pub fn mock_fabric(size_hint: usize) -> MpcFabric {
+pub fn mock_fabric(size_hint: usize) -> MpcFabric<TestCurve> {
     let network = NoRecvNetwork::default();
     let beaver_source = PartyIDBeaverSource::new(PARTY0);
     MpcFabric::new_with_size_hint(size_hint, network, beaver_source)

--- a/benches/growable_buffer.rs
+++ b/benches/growable_buffer.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use mpc_stark::{algebra::scalar::Scalar, buffer::GrowableBuffer};
+use mpc_stark::{algebra::scalar::Scalar, buffer::GrowableBuffer, test_helpers::TestCurve};
 
 // --------------
 // | Benchmarks |
@@ -11,7 +11,7 @@ pub fn buffer_read__sequential(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer_read__sequential");
 
     for buffer_size in [1_000, 10_000, 100_000, 1_000_000] {
-        let buffer: GrowableBuffer<Scalar> = GrowableBuffer::new(buffer_size);
+        let buffer: GrowableBuffer<Scalar<TestCurve>> = GrowableBuffer::new(buffer_size);
 
         group.throughput(Throughput::Elements(buffer_size as u64));
         group.bench_function(BenchmarkId::from_parameter(buffer_size), |b| {

--- a/benches/growable_buffer.rs
+++ b/benches/growable_buffer.rs
@@ -1,5 +1,5 @@
+use ark_mpc::{algebra::scalar::Scalar, buffer::GrowableBuffer, test_helpers::TestCurve};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use mpc_stark::{algebra::scalar::Scalar, buffer::GrowableBuffer, test_helpers::TestCurve};
 
 // --------------
 // | Benchmarks |

--- a/benches/native_msm.rs
+++ b/benches/native_msm.rs
@@ -3,8 +3,9 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use itertools::Itertools;
 use mpc_stark::{
-    algebra::{scalar::Scalar, stark_curve::StarkPoint},
+    algebra::{curve::CurvePoint, scalar::Scalar},
     random_point,
+    test_helpers::TestCurve,
 };
 use rand::thread_rng;
 
@@ -22,7 +23,7 @@ pub fn bench_native_msm(c: &mut Criterion) {
             let scalars = (0..n_elems).map(|_| Scalar::random(&mut rng)).collect_vec();
             let points = (0..n_elems).map(|_| random_point()).collect_vec();
             b.iter(|| {
-                black_box(StarkPoint::msm(&scalars, &points));
+                black_box(CurvePoint::<TestCurve>::msm(&scalars, &points));
             })
         });
     }

--- a/benches/native_msm.rs
+++ b/benches/native_msm.rs
@@ -1,12 +1,12 @@
-//! Defines a benchmark for native multiscalar-multiplication on `Scalar` and `StarkPoint` types
+//! Defines a benchmark for native multiscalar-multiplication on `Scalar` and `CurvePoint` types
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{curve::CurvePoint, scalar::Scalar},
     random_point,
     test_helpers::TestCurve,
 };
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use itertools::Itertools;
 use rand::thread_rng;
 
 /// The maximum power of two to scale the MSM benchmark to

--- a/benches/test_stats.rs
+++ b/benches/test_stats.rs
@@ -1,6 +1,6 @@
 //! A simple benchmark for testing that stats collection is properly working
 
-use mpc_stark::{algebra::scalar::Scalar, test_helpers::execute_mock_mpc, PARTY0, PARTY1};
+use ark_mpc::{algebra::scalar::Scalar, test_helpers::execute_mock_mpc, PARTY0, PARTY1};
 use rand::{distributions::uniform::SampleRange, thread_rng};
 
 #[tokio::main]

--- a/integration/authenticated_curve.rs
+++ b/integration/authenticated_curve.rs
@@ -3,9 +3,9 @@
 use itertools::Itertools;
 use mpc_stark::{
     algebra::{
-        authenticated_stark_point::{
+        authenticated_curve::{
             test_helpers::{modify_mac, modify_public_modifier, modify_share},
-            AuthenticatedStarkPointResult,
+            AuthenticatedPointResult,
         },
         scalar::Scalar,
     },
@@ -144,10 +144,9 @@ fn test_batch_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let party0_values = share_authenticated_point_batch(my_vals.clone(), PARTY0, test_args);
     let party1_values = share_authenticated_point_batch(my_vals, PARTY1, test_args);
 
-    let res = AuthenticatedStarkPointResult::batch_add(&party0_values, &party1_values);
-    let res_open = await_batch_result_with_error(
-        AuthenticatedStarkPointResult::open_authenticated_batch(&res),
-    )?;
+    let res = AuthenticatedPointResult::batch_add(&party0_values, &party1_values);
+    let res_open =
+        await_batch_result_with_error(AuthenticatedPointResult::open_authenticated_batch(&res))?;
 
     assert_point_batches_eq(res_open, expected_result)
 }
@@ -172,10 +171,9 @@ fn test_batch_add_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
     // Add the points in the MPC circuit
     let party0_values = share_authenticated_point_batch(my_vals, PARTY0, test_args);
 
-    let res = AuthenticatedStarkPointResult::batch_add_public(&party0_values, &plaintext_values);
-    let res_open = await_batch_result_with_error(
-        AuthenticatedStarkPointResult::open_authenticated_batch(&res),
-    )?;
+    let res = AuthenticatedPointResult::batch_add_public(&party0_values, &plaintext_values);
+    let res_open =
+        await_batch_result_with_error(AuthenticatedPointResult::open_authenticated_batch(&res))?;
 
     assert_point_batches_eq(res_open, expected_result)
 }
@@ -240,10 +238,9 @@ fn test_batch_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let party0_values = share_authenticated_point_batch(my_vals.clone(), PARTY0, test_args);
     let party1_values = share_authenticated_point_batch(my_vals, PARTY1, test_args);
 
-    let res = AuthenticatedStarkPointResult::batch_sub(&party0_values, &party1_values);
-    let res_open = await_batch_result_with_error(
-        AuthenticatedStarkPointResult::open_authenticated_batch(&res),
-    )?;
+    let res = AuthenticatedPointResult::batch_sub(&party0_values, &party1_values);
+    let res_open =
+        await_batch_result_with_error(AuthenticatedPointResult::open_authenticated_batch(&res))?;
 
     assert_point_batches_eq(res_open, expected_result)
 }
@@ -268,10 +265,9 @@ fn test_batch_sub_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
     // Add the points in the MPC circuit
     let party0_values = share_authenticated_point_batch(my_vals, PARTY0, test_args);
 
-    let res = AuthenticatedStarkPointResult::batch_sub_public(&party0_values, &plaintext_values);
-    let res_open = await_batch_result_with_error(
-        AuthenticatedStarkPointResult::open_authenticated_batch(&res),
-    )?;
+    let res = AuthenticatedPointResult::batch_sub_public(&party0_values, &plaintext_values);
+    let res_open =
+        await_batch_result_with_error(AuthenticatedPointResult::open_authenticated_batch(&res))?;
 
     assert_point_batches_eq(res_open, expected_result)
 }
@@ -310,10 +306,9 @@ fn test_batch_negation(test_args: &IntegrationTestArgs) -> Result<(), String> {
 
     // Compute the expected result in an MPC circuit
     let party0_values = share_authenticated_point_batch(my_values, PARTY0, test_args);
-    let res = AuthenticatedStarkPointResult::batch_neg(&party0_values);
-    let res_open = await_batch_result_with_error(
-        AuthenticatedStarkPointResult::open_authenticated_batch(&res),
-    )?;
+    let res = AuthenticatedPointResult::batch_neg(&party0_values);
+    let res_open =
+        await_batch_result_with_error(AuthenticatedPointResult::open_authenticated_batch(&res))?;
 
     assert_point_batches_eq(expected_res, res_open)
 }
@@ -382,10 +377,9 @@ fn test_batch_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let party0_values = share_authenticated_point_batch(my_vals.clone(), PARTY0, test_args);
     let party1_values = share_authenticated_point_batch(my_vals, PARTY1, test_args);
 
-    let res = AuthenticatedStarkPointResult::batch_sub(&party0_values, &party1_values);
-    let res_open = await_batch_result_with_error(
-        AuthenticatedStarkPointResult::open_authenticated_batch(&res),
-    )?;
+    let res = AuthenticatedPointResult::batch_sub(&party0_values, &party1_values);
+    let res_open =
+        await_batch_result_with_error(AuthenticatedPointResult::open_authenticated_batch(&res))?;
 
     assert_point_batches_eq(res_open, expected_result)
 }
@@ -410,10 +404,9 @@ fn test_batch_mul_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
     // Add the points in the MPC circuit
     let party0_values = share_authenticated_point_batch(my_vals, PARTY0, test_args);
 
-    let res = AuthenticatedStarkPointResult::batch_sub_public(&party0_values, &plaintext_values);
-    let res_open = await_batch_result_with_error(
-        AuthenticatedStarkPointResult::open_authenticated_batch(&res),
-    )?;
+    let res = AuthenticatedPointResult::batch_sub_public(&party0_values, &plaintext_values);
+    let res_open =
+        await_batch_result_with_error(AuthenticatedPointResult::open_authenticated_batch(&res))?;
 
     assert_point_batches_eq(res_open, expected_result)
 }

--- a/integration/authenticated_curve.rs
+++ b/integration/authenticated_curve.rs
@@ -1,7 +1,6 @@
-//! Integration tests for the `AuthenticatedStarkPoint` type
+//! Integration tests for the `AuthenticatedPointResult` type
 
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         authenticated_curve::{
             test_helpers::{modify_mac, modify_public_modifier, modify_share},
@@ -11,6 +10,7 @@ use mpc_stark::{
     },
     random_point, PARTY0, PARTY1,
 };
+use itertools::Itertools;
 use rand::thread_rng;
 
 use crate::{
@@ -151,7 +151,7 @@ fn test_batch_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(res_open, expected_result)
 }
 
-/// Test addition between a batch of `AuthenticatedStarkPoint`s and `StarkPoint`s
+/// Test addition between a batch of `AuthenticatedPointResult`s and `CurvePoint`s
 fn test_batch_add_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -245,7 +245,7 @@ fn test_batch_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(res_open, expected_result)
 }
 
-/// Test addition between a batch of `AuthenticatedStarkPoint`s and `StarkPoint`s
+/// Test addition between a batch of `AuthenticatedPointResult`s and `CurvePoint`s
 fn test_batch_sub_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -384,7 +384,7 @@ fn test_batch_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(res_open, expected_result)
 }
 
-/// Test addition between a batch of `AuthenticatedStarkPoint`s and `StarkPoint`s
+/// Test addition between a batch of `AuthenticatedPointResult`s and `CurvePoint`s
 fn test_batch_mul_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -412,91 +412,91 @@ fn test_batch_mul_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
 }
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_open_authenticated",
+    name: "authenticated_curve_point::test_open_authenticated",
     test_fn: test_open_authenticated
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_open_authenticated__bad_mac",
+    name: "authenticated_curve_point::test_open_authenticated__bad_mac",
     test_fn: test_open_authenticated__bad_mac
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_open_authenticated__bad_share",
+    name: "authenticated_curve_point::test_open_authenticated__bad_share",
     test_fn: test_open_authenticated__bad_share
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_open_authenticated__bad_public_modifier",
+    name: "authenticated_curve_point::test_open_authenticated__bad_public_modifier",
     test_fn: test_open_authenticated__bad_public_modifier
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_addition_public_point",
+    name: "authenticated_curve_point::test_addition_public_point",
     test_fn: test_addition_public_point
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_add",
+    name: "authenticated_curve_point::test_add",
     test_fn: test_add
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_add",
+    name: "authenticated_curve_point::test_batch_add",
     test_fn: test_batch_add
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_add_public",
+    name: "authenticated_curve_point::test_batch_add_public",
     test_fn: test_batch_add_public
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_sub_public_point",
+    name: "authenticated_curve_point::test_sub_public_point",
     test_fn: test_sub_public_point
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_sub",
+    name: "authenticated_curve_point::test_sub",
     test_fn: test_sub
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_sub",
+    name: "authenticated_curve_point::test_batch_sub",
     test_fn: test_batch_sub
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_sub_public",
+    name: "authenticated_curve_point::test_batch_sub_public",
     test_fn: test_batch_sub_public
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_negation",
+    name: "authenticated_curve_point::test_negation",
     test_fn: test_negation
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_negation",
+    name: "authenticated_curve_point::test_batch_negation",
     test_fn: test_batch_negation
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_multiplication_public_scalar",
+    name: "authenticated_curve_point::test_multiplication_public_scalar",
     test_fn: test_multiplication_public_scalar
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_multiplication",
+    name: "authenticated_curve_point::test_multiplication",
     test_fn: test_multiplication
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_mul",
+    name: "authenticated_curve_point::test_batch_mul",
     test_fn: test_batch_mul
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_mul_public",
+    name: "authenticated_curve_point::test_batch_mul_public",
     test_fn: test_batch_mul_public
 });

--- a/integration/authenticated_scalar.rs
+++ b/integration/authenticated_scalar.rs
@@ -18,7 +18,7 @@ use crate::{
         await_result, await_result_batch, await_result_with_error, share_authenticated_scalar,
         share_authenticated_scalar_batch, share_plaintext_value, share_plaintext_values_batch,
     },
-    IntegrationTest, IntegrationTestArgs,
+    IntegrationTest, IntegrationTestArgs, TestScalar,
 };
 
 // -----------
@@ -108,7 +108,7 @@ fn test_add_public_value(test_args: &IntegrationTestArgs) -> Result<(), String> 
     let party0_value = share_plaintext_value(my_value.clone(), PARTY0, &test_args.fabric);
     let party1_value = share_plaintext_value(my_value, PARTY1, &test_args.fabric);
 
-    let plaintext_constant: Scalar = await_result(party1_value);
+    let plaintext_constant: TestScalar = await_result(party1_value);
     let expected_result = await_result(party0_value) + plaintext_constant;
 
     // Compute the result in the MPC circuit
@@ -213,7 +213,7 @@ fn test_sub_public_scalar(test_args: &IntegrationTestArgs) -> Result<(), String>
     let party0_value = share_plaintext_value(my_value.clone(), PARTY0, &test_args.fabric);
     let party1_value = share_plaintext_value(my_value, PARTY1, &test_args.fabric);
 
-    let plaintext_constant: Scalar = await_result(party1_value);
+    let plaintext_constant: TestScalar = await_result(party1_value);
     let expected_result = await_result(party0_value) - plaintext_constant;
 
     // Compute the result in the MPC circuit
@@ -365,7 +365,7 @@ fn test_mul_public_scalar(test_args: &IntegrationTestArgs) -> Result<(), String>
     let party0_value = share_plaintext_value(my_value.clone(), PARTY0, &test_args.fabric);
     let party1_value = share_plaintext_value(my_value, PARTY1, &test_args.fabric);
 
-    let plaintext_constant: Scalar = await_result(party1_value);
+    let plaintext_constant: TestScalar = await_result(party1_value);
     let expected_result = await_result(party0_value) * plaintext_constant;
 
     // Compute the result in the MPC circuit

--- a/integration/authenticated_scalar.rs
+++ b/integration/authenticated_scalar.rs
@@ -1,14 +1,14 @@
-//! Integration tests for arithmetic on the `AuthenticatedScalar` type which provides
+//! Integration tests for arithmetic on the `AuthenticatedScalarResult` type which provides
 //! a malicious-secure primitive
 
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         authenticated_scalar::{test_helpers::*, AuthenticatedScalarResult},
         scalar::Scalar,
     },
     ResultValue, PARTY0, PARTY1,
 };
+use itertools::Itertools;
 use rand::thread_rng;
 use std::ops::Neg;
 

--- a/integration/circuits.rs
+++ b/integration/circuits.rs
@@ -1,13 +1,13 @@
 //! Tests for more complicated operations (i.e. circuits)
 
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         authenticated_curve::AuthenticatedPointResult,
         authenticated_scalar::AuthenticatedScalarResult, scalar::Scalar,
     },
     random_point, PARTY0, PARTY1,
 };
+use itertools::Itertools;
 use rand::thread_rng;
 
 use crate::{

--- a/integration/fabric.rs
+++ b/integration/fabric.rs
@@ -1,6 +1,6 @@
 //! Defines tests for the fabric directly
 
-use mpc_stark::{algebra::scalar::Scalar, PARTY0, PARTY1};
+use ark_mpc::{algebra::scalar::Scalar, PARTY0, PARTY1};
 
 use crate::{
     helpers::{assert_scalars_eq, await_result, share_scalar},

--- a/integration/fabric.rs
+++ b/integration/fabric.rs
@@ -21,14 +21,14 @@ fn test_fabric_share_and_open(test_args: &IntegrationTestArgs) -> Result<(), Str
     let party0_value_opened = party0_value.open();
     let party0_res = await_result(party0_value_opened);
 
-    assert_scalars_eq(party0_res, Scalar::from(0))?;
+    assert_scalars_eq(party0_res, Scalar::from(0u8))?;
 
     // Party 1
     let party1_value = share_scalar(my_party_id, PARTY1, test_args);
     let party1_value_opened = party1_value.open();
     let party1_res = await_result(party1_value_opened);
 
-    assert_scalars_eq(party1_res, Scalar::from(1))
+    assert_scalars_eq(party1_res, Scalar::from(1u8))
 }
 
 inventory::submit!(IntegrationTest {

--- a/integration/helpers.rs
+++ b/integration/helpers.rs
@@ -1,10 +1,8 @@
-//! Defines testing mocks
+//! Defines testing mocks and helpers for integration tests
 
 use std::fmt::Debug;
 
-use futures::{future::join_all, Future};
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         authenticated_curve::AuthenticatedPointResult,
         authenticated_scalar::AuthenticatedScalarResult, mpc_curve::MpcPointResult,
@@ -14,6 +12,8 @@ use mpc_stark::{
     network::{NetworkPayload, PartyId},
     {MpcFabric, ResultHandle, ResultValue},
 };
+use futures::{future::join_all, Future};
+use itertools::Itertools;
 use tokio::runtime::Handle;
 
 // -----------
@@ -147,7 +147,7 @@ pub(crate) fn share_point(
     sender: PartyId,
     test_args: &IntegrationTestArgs,
 ) -> MpcPointResult<TestCurve> {
-    // Share the point then cast to an `MpcStarkPoint`
+    // Share the point then cast to an `MpcPointResult`
     let authenticated_point = share_authenticated_point(value, sender, test_args);
     authenticated_point.mpc_share()
 }

--- a/integration/main.rs
+++ b/integration/main.rs
@@ -1,5 +1,7 @@
 use std::{borrow::Borrow, io::Write, net::SocketAddr, process::exit, thread, time::Duration};
 
+use ark_curve25519::Curve25519Config;
+use ark_ec::twisted_edwards::Projective;
 use clap::Parser;
 use colored::Colorize;
 use dns_lookup::lookup_host;
@@ -7,28 +9,36 @@ use env_logger::Builder;
 use futures::{SinkExt, StreamExt};
 use helpers::PartyIDBeaverSource;
 use mpc_stark::{
+    algebra::{curve::CurvePoint, scalar::Scalar},
     network::{NetworkOutbound, NetworkPayload, QuicTwoPartyNet},
     MpcFabric, PARTY0,
 };
 use tokio::runtime::{Builder as RuntimeBuilder, Handle};
 use tracing::log::{self, LevelFilter};
 
+mod authenticated_curve;
 mod authenticated_scalar;
-mod authenticated_stark_point;
 mod circuits;
 mod fabric;
 mod helpers;
+mod mpc_curve;
 mod mpc_scalar;
-mod mpc_stark_point;
 
 /// The amount of time to sleep after sending a shutdown
 const SHUTDOWN_TIMEOUT_MS: u64 = 3_000; // 3 seconds
+
+/// The curve used for testing, set to curve25519
+pub type TestCurve = Projective<Curve25519Config>;
+/// The curve point type used for testing
+pub type TestCurvePoint = CurvePoint<TestCurve>;
+/// The scalar point ype used for testing
+pub type TestScalar = Scalar<TestCurve>;
 
 /// Integration test arguments, common to all tests
 #[derive(Clone, Debug)]
 struct IntegrationTestArgs {
     party_id: u64,
-    fabric: MpcFabric,
+    fabric: MpcFabric<TestCurve>,
 }
 
 /// Integration test format

--- a/integration/main.rs
+++ b/integration/main.rs
@@ -2,17 +2,17 @@ use std::{borrow::Borrow, io::Write, net::SocketAddr, process::exit, thread, tim
 
 use ark_curve25519::Curve25519Config;
 use ark_ec::twisted_edwards::Projective;
+use ark_mpc::{
+    algebra::{curve::CurvePoint, scalar::Scalar},
+    network::{NetworkOutbound, NetworkPayload, QuicTwoPartyNet},
+    MpcFabric, PARTY0,
+};
 use clap::Parser;
 use colored::Colorize;
 use dns_lookup::lookup_host;
 use env_logger::Builder;
 use futures::{SinkExt, StreamExt};
 use helpers::PartyIDBeaverSource;
-use mpc_stark::{
-    algebra::{curve::CurvePoint, scalar::Scalar},
-    network::{NetworkOutbound, NetworkPayload, QuicTwoPartyNet},
-    MpcFabric, PARTY0,
-};
 use tokio::runtime::{Builder as RuntimeBuilder, Handle};
 use tracing::log::{self, LevelFilter};
 

--- a/integration/mpc_curve.rs
+++ b/integration/mpc_curve.rs
@@ -3,9 +3,9 @@
 use itertools::Itertools;
 use mpc_stark::{
     algebra::{
-        mpc_stark_point::MpcStarkPointResult,
+        curve::CurvePointResult,
+        mpc_curve::MpcPointResult,
         scalar::{Scalar, ScalarResult},
-        stark_curve::StarkPointResult,
     },
     random_point, PARTY0, PARTY1,
 };
@@ -17,7 +17,7 @@ use crate::{
         share_plaintext_value, share_plaintext_values_batch, share_point, share_point_batch,
         share_scalar, share_scalar_batch,
     },
-    IntegrationTest, IntegrationTestArgs,
+    IntegrationTest, IntegrationTestArgs, TestCurve,
 };
 
 /// Test addition of `MpcStarkPoint` types
@@ -89,13 +89,13 @@ fn test_batch_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let party0_values = share_point_batch(points.clone(), PARTY0, test_args);
     let party1_values = share_point_batch(points, PARTY1, test_args);
 
-    let res = MpcStarkPointResult::batch_add(&party0_values, &party1_values);
-    let opened_res = await_result_batch(&MpcStarkPointResult::open_batch(&res));
+    let res = MpcPointResult::batch_add(&party0_values, &party1_values);
+    let opened_res = await_result_batch(&MpcPointResult::open_batch(&res));
 
     assert_point_batches_eq(opened_res, expected_result)
 }
 
-/// Tests addition between a batch of `MpcStarkPointResult`s and `StarkPointResult`s
+/// Tests addition between a batch of `MpcPointResult`s and `StarkPointResult`s
 fn test_batch_add_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -114,8 +114,8 @@ fn test_batch_add_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
 
     // Secret share the values and add them together in the MPC circuit
     let party0_values = share_point_batch(points, PARTY0, test_args);
-    let res = MpcStarkPointResult::batch_add_public(&party0_values, &plaintext_values);
-    let res_open = await_result_batch(&MpcStarkPointResult::open_batch(&res));
+    let res = MpcPointResult::batch_add_public(&party0_values, &plaintext_values);
+    let res_open = await_result_batch(&MpcPointResult::open_batch(&res));
 
     assert_point_batches_eq(res_open, expected_result)
 }
@@ -189,8 +189,8 @@ fn test_batch_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let party0_values = share_point_batch(points.clone(), PARTY0, test_args);
     let party1_values = share_point_batch(points, PARTY1, test_args);
 
-    let res = MpcStarkPointResult::batch_sub(&party0_values, &party1_values);
-    let opened_res = await_result_batch(&MpcStarkPointResult::open_batch(&res));
+    let res = MpcPointResult::batch_sub(&party0_values, &party1_values);
+    let opened_res = await_result_batch(&MpcPointResult::open_batch(&res));
 
     assert_point_batches_eq(opened_res, expected_result)
 }
@@ -214,8 +214,8 @@ fn test_batch_sub_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
 
     // Secret share the values and add them together in the MPC circuit
     let party0_values = share_point_batch(points, PARTY0, test_args);
-    let res = MpcStarkPointResult::batch_sub_public(&party0_values, &plaintext_values);
-    let res_open = await_result_batch(&MpcStarkPointResult::open_batch(&res));
+    let res = MpcPointResult::batch_sub_public(&party0_values, &plaintext_values);
+    let res_open = await_result_batch(&MpcPointResult::open_batch(&res));
 
     assert_point_batches_eq(res_open, expected_result)
 }
@@ -258,8 +258,8 @@ fn test_batch_neg(test_args: &IntegrationTestArgs) -> Result<(), String> {
 
     // Secret share the values and add them together in the MPC circuit
     let party0_values = share_point_batch(points, PARTY0, test_args);
-    let res = MpcStarkPointResult::batch_neg(&party0_values);
-    let opened_res = await_result_batch(&MpcStarkPointResult::open_batch(&res));
+    let res = MpcPointResult::batch_neg(&party0_values);
+    let opened_res = await_result_batch(&MpcPointResult::open_batch(&res));
 
     assert_point_batches_eq(opened_res, expected_result)
 }
@@ -273,12 +273,12 @@ fn test_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let scalar = Scalar::random(&mut rng);
 
     // Share the values with the counterparty
-    let plaintext_point: StarkPointResult = share_plaintext_value(
+    let plaintext_point: CurvePointResult<TestCurve> = share_plaintext_value(
         test_args.fabric.allocate_point(point),
         PARTY0,
         &test_args.fabric,
     );
-    let plaintext_scalar: ScalarResult = share_plaintext_value(
+    let plaintext_scalar: ScalarResult<TestCurve> = share_plaintext_value(
         test_args.fabric.allocate_scalar(scalar),
         PARTY1,
         &test_args.fabric,
@@ -311,7 +311,7 @@ fn test_mul_scalar_constant(test_args: &IntegrationTestArgs) -> Result<(), Strin
         PARTY0,
         &test_args.fabric,
     );
-    let plaintext_scalar: ScalarResult = share_plaintext_value(
+    let plaintext_scalar: ScalarResult<TestCurve> = share_plaintext_value(
         test_args.fabric.allocate_scalar(scalar),
         PARTY1,
         &test_args.fabric,
@@ -361,13 +361,13 @@ fn test_batch_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let party0_values = share_point_batch(points, PARTY0, test_args);
     let party1_values = share_scalar_batch(scalars, PARTY1, test_args);
 
-    let res = MpcStarkPointResult::batch_mul(&party1_values, &party0_values);
-    let opened_res = await_result_batch(&MpcStarkPointResult::open_batch(&res));
+    let res = MpcPointResult::batch_mul(&party1_values, &party0_values);
+    let opened_res = await_result_batch(&MpcPointResult::open_batch(&res));
 
     assert_point_batches_eq(opened_res, expected_result)
 }
 
-/// Test multiplication of a batch of `MpcStarkPointResult`s with `ScalarResult`s
+/// Test multiplication of a batch of `MpcPointResult`s with `ScalarResult`s
 fn test_batch_mul_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let mut rng = thread_rng();
@@ -390,8 +390,8 @@ fn test_batch_mul_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
 
     // Secret share the values and add them together in the MPC circuit
     let party0_values = share_point_batch(points, PARTY0, test_args);
-    let res = MpcStarkPointResult::batch_mul_public(&plaintext_values, &party0_values);
-    let res_open = await_result_batch(&MpcStarkPointResult::open_batch(&res));
+    let res = MpcPointResult::batch_mul_public(&plaintext_values, &party0_values);
+    let res_open = await_result_batch(&MpcPointResult::open_batch(&res));
 
     assert_point_batches_eq(res_open, expected_result)
 }

--- a/integration/mpc_curve.rs
+++ b/integration/mpc_curve.rs
@@ -1,7 +1,6 @@
-//! Defines tests for the `MpcStarkPoint` type and arithmetic on this type
+//! Defines tests for the `MpcPointResult` type and arithmetic on this type
 
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         curve::CurvePointResult,
         mpc_curve::MpcPointResult,
@@ -9,6 +8,7 @@ use mpc_stark::{
     },
     random_point, PARTY0, PARTY1,
 };
+use itertools::Itertools;
 use rand::thread_rng;
 
 use crate::{
@@ -20,7 +20,7 @@ use crate::{
     IntegrationTest, IntegrationTestArgs, TestCurve,
 };
 
-/// Test addition of `MpcStarkPoint` types
+/// Test addition of `MpcPointResult` types
 fn test_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let val = random_point();
     let my_value = test_args.fabric.allocate_point(val);
@@ -42,7 +42,7 @@ fn test_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test addition of `MpcStarkPoint` with `StarkPoint`
+/// Test addition of `MpcPointResult` with `CurvePoint`
 ///
 /// Party 0 chooses an MPC point and party 1 chooses a plaintext point
 fn test_add_point_constant(test_args: &IntegrationTestArgs) -> Result<(), String> {
@@ -67,7 +67,7 @@ fn test_add_point_constant(test_args: &IntegrationTestArgs) -> Result<(), String
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test adding a batch of `MpcStarkPoint` types
+/// Test adding a batch of `MpcPointResult` types
 fn test_batch_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -95,7 +95,7 @@ fn test_batch_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(opened_res, expected_result)
 }
 
-/// Tests addition between a batch of `MpcPointResult`s and `StarkPointResult`s
+/// Tests addition between a batch of `MpcPointResult`s and `CurvePointResult`s
 fn test_batch_add_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -120,7 +120,7 @@ fn test_batch_add_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
     assert_point_batches_eq(res_open, expected_result)
 }
 
-/// Test subtraction of `MpcStarkPoint` types
+/// Test subtraction of `MpcPointResult` types
 fn test_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let val = random_point();
     let my_value = test_args.fabric.allocate_point(val);
@@ -142,7 +142,7 @@ fn test_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test subtraction of `MpcStarkPoint` with `StarkPoint`
+/// Test subtraction of `MpcPointResult` with `PointResult`
 ///
 /// Party 0 chooses an MPC point and party 1 chooses a plaintext point
 fn test_sub_point_constant(test_args: &IntegrationTestArgs) -> Result<(), String> {
@@ -167,7 +167,7 @@ fn test_sub_point_constant(test_args: &IntegrationTestArgs) -> Result<(), String
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test subtracting a batch of `MpcStarkPoint` types
+/// Test subtracting a batch of `MpcPointResult` types
 fn test_batch_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -195,7 +195,7 @@ fn test_batch_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(opened_res, expected_result)
 }
 
-/// Test subtracting a batch of `MpcStarkPoint` types and `StarkPointResult`s
+/// Test subtracting a batch of `MpcPointResult` types and `CurvePointResult`s
 fn test_batch_sub_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -220,7 +220,7 @@ fn test_batch_sub_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
     assert_point_batches_eq(res_open, expected_result)
 }
 
-/// Test negation of `MpcStarkPoint` types
+/// Test negation of `MpcPointResult` types
 fn test_neg(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let val = random_point();
     let my_value = test_args.fabric.allocate_point(val);
@@ -240,7 +240,7 @@ fn test_neg(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test negating a batch of `MpcStarkPoint` types
+/// Test negating a batch of `MpcPointResult` types
 fn test_batch_neg(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -264,7 +264,7 @@ fn test_batch_neg(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(opened_res, expected_result)
 }
 
-/// Test multiplication of an `MpcStarkPoint` type with an `MpcScalarResult` type
+/// Test multiplication of an `MpcPointResult` type with an `MpcScalarResult` type
 ///
 /// Party 0 chooses the point, party 1 chooses the scalar
 fn test_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
@@ -331,7 +331,7 @@ fn test_mul_scalar_constant(test_args: &IntegrationTestArgs) -> Result<(), Strin
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test multiplying a batch of `MpcStarkPoint` types
+/// Test multiplying a batch of `MpcPointResult` types
 ///
 /// Party 0 chooses the points and party 1 chooses the scalars
 fn test_batch_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
@@ -397,71 +397,71 @@ fn test_batch_mul_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
 }
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_add",
+    name: "mpc_point::test_add",
     test_fn: test_add,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_add_point_constant",
+    name: "mpc_point::test_add_point_constant",
     test_fn: test_add_point_constant,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_add",
+    name: "mpc_point::test_batch_add",
     test_fn: test_batch_add,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_add_public",
+    name: "mpc_point::test_batch_add_public",
     test_fn: test_batch_add_public,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_sub",
+    name: "mpc_point::test_sub",
     test_fn: test_sub,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_sub_point_constant",
+    name: "mpc_point::test_sub_point_constant",
     test_fn: test_sub_point_constant,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_sub",
+    name: "mpc_point::test_batch_sub",
     test_fn: test_batch_sub,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_sub_public",
+    name: "mpc_point::test_batch_sub_public",
     test_fn: test_batch_sub_public,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_neg",
+    name: "mpc_point::test_neg",
     test_fn: test_neg,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_neg",
+    name: "mpc_point::test_batch_neg",
     test_fn: test_batch_neg,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_mul",
+    name: "mpc_point::test_mul",
     test_fn: test_mul,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_mul_scalar_constant",
+    name: "mpc_point::test_mul_scalar_constant",
     test_fn: test_mul_scalar_constant,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_mul",
+    name: "mpc_point::test_batch_mul",
     test_fn: test_batch_mul,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_mul_public",
+    name: "mpc_point::test_batch_mul_public",
     test_fn: test_batch_mul_public,
 });

--- a/integration/mpc_scalar.rs
+++ b/integration/mpc_scalar.rs
@@ -1,12 +1,12 @@
 //! Defines unit tests for `MpcScalarResult` types
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         mpc_scalar::MpcScalarResult,
         scalar::{Scalar, ScalarResult},
     },
     PARTY0, PARTY1,
 };
+use itertools::Itertools;
 use rand::thread_rng;
 use std::ops::Neg;
 

--- a/integration/mpc_scalar.rs
+++ b/integration/mpc_scalar.rs
@@ -1,8 +1,11 @@
 //! Defines unit tests for `MpcScalarResult` types
 use itertools::Itertools;
 use mpc_stark::{
-    algebra::{mpc_scalar::MpcScalarResult, scalar::Scalar},
-    ResultHandle, PARTY0, PARTY1,
+    algebra::{
+        mpc_scalar::MpcScalarResult,
+        scalar::{Scalar, ScalarResult},
+    },
+    PARTY0, PARTY1,
 };
 use rand::thread_rng;
 use std::ops::Neg;
@@ -12,7 +15,7 @@ use crate::{
         assert_scalar_batches_eq, assert_scalars_eq, await_result, await_result_batch,
         share_plaintext_value, share_plaintext_values_batch, share_scalar, share_scalar_batch,
     },
-    IntegrationTest, IntegrationTestArgs,
+    IntegrationTest, IntegrationTestArgs, TestCurve,
 };
 
 /// Test addition of `MpcScalarResult` types
@@ -20,7 +23,7 @@ fn test_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     // Each party allocates a random value
     let mut rng = thread_rng();
     let val = Scalar::random(&mut rng);
-    let my_value: ResultHandle<Scalar> = test_args.fabric.allocate_scalar(val);
+    let my_value: ScalarResult<TestCurve> = test_args.fabric.allocate_scalar(val);
 
     // Share the value with the counterparty
     let party0_value = share_plaintext_value(my_value.clone(), PARTY0, &test_args.fabric);
@@ -46,7 +49,7 @@ fn test_add_scalar_constant(test_args: &IntegrationTestArgs) -> Result<(), Strin
     // Each party allocates a random value
     let mut rng = thread_rng();
     let val = Scalar::random(&mut rng);
-    let my_value: ResultHandle<Scalar> = test_args.fabric.allocate_scalar(val);
+    let my_value: ScalarResult<TestCurve> = test_args.fabric.allocate_scalar(val);
 
     // Share the value with the counterparty
     let party0_value = share_plaintext_value(my_value.clone(), PARTY0, &test_args.fabric);

--- a/src/algebra/authenticated_scalar.rs
+++ b/src/algebra/authenticated_scalar.rs
@@ -30,7 +30,7 @@ use super::{
 /// The number of results wrapped by an `AuthenticatedScalarResult<C>`
 pub const AUTHENTICATED_SCALAR_RESULT_LEN: usize = 3;
 
-/// A maliciously secure wrapper around an `MpcScalarResult<C>`, includes a MAC as per the
+/// A maliciously secure wrapper around an `MpcScalarResult`, includes a MAC as per the
 /// SPDZ protocol: https://eprint.iacr.org/2011/535.pdf
 /// that ensures security against a malicious adversary
 #[derive(Clone)]
@@ -42,7 +42,7 @@ pub struct AuthenticatedScalarResult<C: CurveGroup> {
     /// If the value is `x`, parties hold secret shares of the value
     /// \delta * x for the global MAC key `\delta`. The parties individually
     /// hold secret shares of this MAC key [\delta], so we can very naturally
-    /// extend the secret share arithmetic of the underlying `MpcScalarResult<C>` to
+    /// extend the secret share arithmetic of the underlying `MpcScalarResult` to
     /// the MAC updates as well
     pub(crate) mac: MpcScalarResult<C>,
     /// The public modifier tracks additions and subtractions of public values to the
@@ -65,7 +65,7 @@ impl<C: CurveGroup> Debug for AuthenticatedScalarResult<C> {
 impl<C: CurveGroup> AuthenticatedScalarResult<C> {
     /// Create a new result from the given shared value
     pub fn new_shared(value: ScalarResult<C>) -> Self {
-        // Create an `MpcScalarResult<C>` to represent the fact that this is a shared value
+        // Create an `MpcScalarResult` to represent the fact that this is a shared value
         let fabric = value.fabric.clone();
 
         let mpc_value = MpcScalarResult::new_shared(value);
@@ -113,7 +113,7 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
     /// Create a nwe shared batch of values from a batch network result
     ///
     /// The batch result combines the batch into one result, so it must be split out
-    /// first before creating the `AuthenticatedScalarResult<C>`s
+    /// first before creating the `AuthenticatedScalarResult`s
     pub fn new_shared_from_batch_result(
         values: BatchScalarResult<C>,
         n: usize,
@@ -130,13 +130,13 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
         Self::new_shared_batch(&scalar_results)
     }
 
-    /// Get the raw share as an `MpcScalarResult<C>`
+    /// Get the raw share as an `MpcScalarResult`
     #[cfg(feature = "test_helpers")]
     pub fn mpc_share(&self) -> MpcScalarResult<C> {
         self.share.clone()
     }
 
-    /// Get the raw share as a `ScalarResult<C>`
+    /// Get the raw share as a `ScalarResult`
     pub fn share(&self) -> ScalarResult<C> {
         self.share.to_scalar()
     }
@@ -162,7 +162,7 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
         MpcScalarResult::open_batch(&values.iter().map(|val| val.share.clone()).collect_vec())
     }
 
-    /// Convert a flattened iterator into a batch of `AuthenticatedScalarResult<C>`s
+    /// Convert a flattened iterator into a batch of `AuthenticatedScalarResult`s
     ///
     /// We assume that the iterator has been flattened in the same way order that `Self::id`s returns
     /// the `AuthenticatedScalar<C>`'s values: `[share, mac, public_modifier]`
@@ -387,7 +387,7 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
     }
 }
 
-/// The value that results from opening an `AuthenticatedScalarResult<C>` and checking its
+/// The value that results from opening an `AuthenticatedScalarResult` and checking its
 /// MAC. This encapsulates both the underlying value and the result of the MAC check
 #[derive(Clone)]
 pub struct AuthenticatedScalarOpenResult<C: CurveGroup> {
@@ -484,7 +484,7 @@ impl<C: CurveGroup> Add<&AuthenticatedScalarResult<C>> for &AuthenticatedScalarR
 impl_borrow_variants!(AuthenticatedScalarResult<C>, Add, add, +, AuthenticatedScalarResult<C>, Output=AuthenticatedScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> AuthenticatedScalarResult<C> {
-    /// Add two batches of `AuthenticatedScalarResult<C>`s
+    /// Add two batches of `AuthenticatedScalarResult`s
     pub fn batch_add(
         a: &[AuthenticatedScalarResult<C>],
         b: &[AuthenticatedScalarResult<C>],
@@ -533,11 +533,11 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
             },
         );
 
-        // Collect the gate results into a series of `AuthenticatedScalarResult<C>`s
+        // Collect the gate results into a series of `AuthenticatedScalarResult`s
         AuthenticatedScalarResult::from_flattened_iterator(gate_results.into_iter())
     }
 
-    /// Add a batch of `AuthenticatedScalarResult<C>`s to a batch of `ScalarResult<C>`s
+    /// Add a batch of `AuthenticatedScalarResult`s to a batch of `ScalarResult`s
     pub fn batch_add_public(
         a: &[AuthenticatedScalarResult<C>],
         b: &[ScalarResult<C>],
@@ -704,7 +704,7 @@ impl<C: CurveGroup> Sub<&AuthenticatedScalarResult<C>> for &AuthenticatedScalarR
 impl_borrow_variants!(AuthenticatedScalarResult<C>, Sub, sub, -, AuthenticatedScalarResult<C>, Output=AuthenticatedScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> AuthenticatedScalarResult<C> {
-    /// Add two batches of `AuthenticatedScalarResult<C>`s
+    /// Add two batches of `AuthenticatedScalarResult`s
     pub fn batch_sub(
         a: &[AuthenticatedScalarResult<C>],
         b: &[AuthenticatedScalarResult<C>],
@@ -753,11 +753,11 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
             },
         );
 
-        // Collect the gate results into a series of `AuthenticatedScalarResult<C>`s
+        // Collect the gate results into a series of `AuthenticatedScalarResult`s
         AuthenticatedScalarResult::from_flattened_iterator(gate_results.into_iter())
     }
 
-    /// Subtract a batch of `ScalarResult<C>`s from a batch of `AuthenticatedScalarResult<C>`s
+    /// Subtract a batch of `ScalarResult`s from a batch of `AuthenticatedScalarResult`s
     pub fn batch_sub_public(
         a: &[AuthenticatedScalarResult<C>],
         b: &[ScalarResult<C>],
@@ -813,7 +813,7 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
             },
         );
 
-        // Collect the gate results into a series of `AuthenticatedScalarResult<C>`s
+        // Collect the gate results into a series of `AuthenticatedScalarResult`s
         AuthenticatedScalarResult::from_flattened_iterator(gate_results.into_iter())
     }
 }
@@ -834,7 +834,7 @@ impl<C: CurveGroup> Neg for &AuthenticatedScalarResult<C> {
 impl_borrow_variants!(AuthenticatedScalarResult<C>, Neg, neg, -, C: CurveGroup);
 
 impl<C: CurveGroup> AuthenticatedScalarResult<C> {
-    /// Negate a batch of `AuthenticatedScalarResult<C>`s
+    /// Negate a batch of `AuthenticatedScalarResult`s
     pub fn batch_neg(a: &[AuthenticatedScalarResult<C>]) -> Vec<AuthenticatedScalarResult<C>> {
         if a.is_empty() {
             return vec![];
@@ -951,7 +951,7 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
         AuthenticatedScalarResult::batch_add(&de_plus_db, &ea_plus_c)
     }
 
-    /// Multiply a batch of `AuthenticatedScalarResult<C>`s by a batch of `ScalarResult<C>`s
+    /// Multiply a batch of `AuthenticatedScalarResult`s by a batch of `ScalarResult`s
     pub fn batch_mul_public(
         a: &[AuthenticatedScalarResult<C>],
         b: &[ScalarResult<C>],
@@ -1049,12 +1049,12 @@ pub mod test_helpers {
 
     use super::AuthenticatedScalarResult;
 
-    /// Modify the MAC of an `AuthenticatedScalarResult<C>`
+    /// Modify the MAC of an `AuthenticatedScalarResult`
     pub fn modify_mac<C: CurveGroup>(val: &mut AuthenticatedScalarResult<C>, new_value: Scalar<C>) {
         val.mac = val.fabric().allocate_scalar(new_value).into()
     }
 
-    /// Modify the underlying secret share of an `AuthenticatedScalarResult<C>`
+    /// Modify the underlying secret share of an `AuthenticatedScalarResult`
     pub fn modify_share<C: CurveGroup>(
         val: &mut AuthenticatedScalarResult<C>,
         new_value: Scalar<C>,
@@ -1062,7 +1062,7 @@ pub mod test_helpers {
         val.share = val.fabric().allocate_scalar(new_value).into()
     }
 
-    /// Modify the public modifier of an `AuthenticatedScalarResult<C>` by adding an offset
+    /// Modify the public modifier of an `AuthenticatedScalarResult` by adding an offset
     pub fn modify_public_modifier<C: CurveGroup>(
         val: &mut AuthenticatedScalarResult<C>,
         new_value: Scalar<C>,

--- a/src/algebra/curve.rs
+++ b/src/algebra/curve.rs
@@ -864,7 +864,7 @@ impl<C: CurveGroup> CurvePointResult<C> {
 mod test {
     use rand::thread_rng;
 
-    use crate::{algebra::test_helper::TestCurve, test_helpers::mock_fabric};
+    use crate::{test_helpers::mock_fabric, test_helpers::TestCurve};
 
     use super::*;
 

--- a/src/algebra/macros.rs
+++ b/src/algebra/macros.rs
@@ -4,9 +4,9 @@
 /// implements the same arithmetic on the owned and partially-owned variants
 macro_rules! impl_borrow_variants {
     // Single type trait
-    ($target:ty, $trait:ident, $fn_name:ident, $op:tt, $($gen:ident: $gen_ty:ty),*) => {
+    ($target:ty, $trait:ident, $fn_name:ident, $op:tt, $($gen:ident: $gen_ty:ident),*) => {
         // Single implementation, owned target type
-        impl<$($gen),*> $trait for $target {
+        impl<$($gen:$gen_ty),*> $trait for $target {
             type Output = $target;
 
             fn $fn_name(self) -> Self::Output {
@@ -16,14 +16,14 @@ macro_rules! impl_borrow_variants {
     };
 
     // Output type same as left hand side
-    ($lhs:ty, $trait:ident, $fn_name:ident, $op:tt, $rhs:ty, $($gen:ident: $gen_ty:ty),*) => {
+    ($lhs:ty, $trait:ident, $fn_name:ident, $op:tt, $rhs:ty, $($gen:ident: $gen_ty:ident),*) => {
         impl_borrow_variants!($lhs, $trait, $fn_name, $op, $rhs, Output=$lhs, $($gen: $gen_ty),*);
     };
 
     // Output type specified
-    ($lhs:ty, $trait:ident, $fn_name:ident, $op:tt, $rhs:ty, Output=$out_type:ty, $($gen:ident: $gen_ty:ty),*) => {
+    ($lhs:ty, $trait:ident, $fn_name:ident, $op:tt, $rhs:ty, Output=$out_type:ty, $($gen:ident: $gen_ty:ident),*) => {
         /// lhs borrowed, rhs owned
-        impl<'a, $($gen),*> $trait<$rhs> for &'a $lhs {
+        impl<'a, $($gen: $gen_ty),*> $trait<$rhs> for &'a $lhs {
             type Output = $out_type;
 
             fn $fn_name(self, rhs: $rhs) -> Self::Output {
@@ -32,7 +32,7 @@ macro_rules! impl_borrow_variants {
         }
 
         /// lhs owned, rhs borrowed
-        impl<'a, $($gen),*> $trait<&'a $rhs> for $lhs {
+        impl<'a, $($gen: $gen_ty),*> $trait<&'a $rhs> for $lhs {
             type Output = $out_type;
 
             fn $fn_name(self, rhs: &'a $rhs) -> Self::Output {
@@ -41,7 +41,7 @@ macro_rules! impl_borrow_variants {
         }
 
         /// lhs owned, rhs owned
-        impl<$($gen),*> $trait<$rhs> for $lhs {
+        impl<$($gen: $gen_ty),*> $trait<$rhs> for $lhs {
             type Output = $out_type;
 
             fn $fn_name(self, rhs: $rhs) -> Self::Output {
@@ -53,13 +53,13 @@ macro_rules! impl_borrow_variants {
 
 /// A macro to implement commutative variants of a binary operation
 macro_rules! impl_commutative {
-    ($lhs:ty, $trait:ident, $fn_name:ident, $op:tt, $rhs:ty, $($gen:ident: $gen_ty:ty),*) => {
+    ($lhs:ty, $trait:ident, $fn_name:ident, $op:tt, $rhs:ty, $($gen:ident: $gen_ty:ident),*) => {
         impl_commutative!($lhs, $trait, $fn_name, $op, $rhs, Output=$lhs, $($gen: $gen_ty),*);
     };
 
-    ($lhs:ty, $trait:ident, $fn_name:ident, $op:tt, $rhs:ty, Output=$out_type:ty, $($gen:ident: $gen_ty:ty),*) => {
+    ($lhs:ty, $trait:ident, $fn_name:ident, $op:tt, $rhs:ty, Output=$out_type:ty, $($gen:ident: $gen_ty:ident),*) => {
         /// lhs borrowed, rhs borrowed
-        impl<'a, $($gen),*> $trait<&'a $lhs> for &'a $rhs {
+        impl<'a, $($gen: $gen_ty),*> $trait<&'a $lhs> for &'a $rhs {
             type Output = $out_type;
 
             fn $fn_name(self, rhs: &'a $lhs) -> Self::Output {
@@ -68,7 +68,7 @@ macro_rules! impl_commutative {
         }
 
         /// lhs borrowed, rhs owned
-        impl<'a, $($gen),*> $trait<$lhs> for &'a $rhs
+        impl<'a, $($gen: $gen_ty),*> $trait<$lhs> for &'a $rhs
         {
             type Output = $out_type;
 
@@ -78,7 +78,7 @@ macro_rules! impl_commutative {
         }
 
         /// lhs owned, rhs borrowed
-        impl<'a, $($gen),*> $trait<&'a $lhs> for $rhs
+        impl<'a, $($gen: $gen_ty),*> $trait<&'a $lhs> for $rhs
         {
             type Output = $out_type;
 
@@ -88,7 +88,7 @@ macro_rules! impl_commutative {
         }
 
         /// lhs owned, rhs owned
-        impl<$($gen),*> $trait<$lhs> for $rhs
+        impl<$($gen: $gen_ty),*> $trait<$lhs> for $rhs
         {
             type Output = $out_type;
 

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -9,14 +9,11 @@ pub mod mpc_scalar;
 pub mod scalar;
 
 /// Helpers useful for testing throughout the `algebra` module
-#[cfg(test)]
+#[cfg(any(test, feature = "test_helpers"))]
 pub(crate) mod test_helper {
-    use std::iter;
-
-    use super::scalar::Scalar;
+    use super::{curve::CurvePoint, scalar::Scalar};
 
     use ark_curve25519::EdwardsProjective as Curve25519Projective;
-    use ark_ec::CurveGroup;
     use ark_ff::PrimeField;
     use num_bigint::BigUint;
     use rand::thread_rng;
@@ -27,12 +24,14 @@ pub(crate) mod test_helper {
 
     /// A curve used for testing algebra implementations, set to curve25519
     pub type TestCurve = Curve25519Projective;
+    /// A curve point on the test curve
+    pub type TestCurvePoint = CurvePoint<TestCurve>;
 
     /// Generate a random point, by multiplying the basepoint with a random scalar
-    pub fn random_point() -> TestCurve {
+    pub fn random_point() -> TestCurvePoint {
         let mut rng = thread_rng();
         let scalar = Scalar::random(&mut rng);
-        let point = TestCurve::generator() * scalar;
+        let point = TestCurvePoint::generator() * scalar;
         point * scalar
     }
 

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -11,32 +11,8 @@ pub mod scalar;
 /// Helpers useful for testing throughout the `algebra` module
 #[cfg(any(test, feature = "test_helpers"))]
 pub(crate) mod test_helper {
-    use super::{curve::CurvePoint, scalar::Scalar};
-
     use ark_curve25519::EdwardsProjective as Curve25519Projective;
-    use ark_ff::PrimeField;
-    use num_bigint::BigUint;
-    use rand::thread_rng;
-
-    // -----------
-    // | Helpers |
-    // -----------
 
     /// A curve used for testing algebra implementations, set to curve25519
     pub type TestCurve = Curve25519Projective;
-    /// A curve point on the test curve
-    pub type TestCurvePoint = CurvePoint<TestCurve>;
-
-    /// Generate a random point, by multiplying the basepoint with a random scalar
-    pub fn random_point() -> TestCurvePoint {
-        let mut rng = thread_rng();
-        let scalar = Scalar::random(&mut rng);
-        let point = TestCurvePoint::generator() * scalar;
-        point * scalar
-    }
-
-    /// Convert a prime field element to a `BigUint`
-    pub fn prime_field_to_biguint<F: PrimeField>(val: &F) -> BigUint {
-        (*val).into()
-    }
 }

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -7,12 +7,3 @@ pub mod macros;
 pub mod mpc_curve;
 pub mod mpc_scalar;
 pub mod scalar;
-
-/// Helpers useful for testing throughout the `algebra` module
-#[cfg(any(test, feature = "test_helpers"))]
-pub(crate) mod test_helper {
-    use ark_curve25519::EdwardsProjective as Curve25519Projective;
-
-    /// A curve used for testing algebra implementations, set to curve25519
-    pub type TestCurve = Curve25519Projective;
-}

--- a/src/algebra/mpc_curve.rs
+++ b/src/algebra/mpc_curve.rs
@@ -210,7 +210,7 @@ impl<C: CurveGroup> MpcPointResult<C> {
             .collect_vec()
     }
 
-    /// Add a batch of `MpcPointResult<C>s` to a batch of `CurvePointResult<C><C>`s
+    /// Add a batch of `MpcPointResults` to a batch of `CurvePointResult`s
     pub fn batch_add_public(
         a: &[MpcPointResult<C>],
         b: &[CurvePointResult<C>],
@@ -479,7 +479,7 @@ impl_borrow_variants!(MpcPointResult<C>, Mul, mul, *, MpcScalarResult<C>, C: Cur
 impl_commutative!(MpcPointResult<C>, Mul, mul, *, MpcScalarResult<C>, C:CurveGroup);
 
 impl<C: CurveGroup> MpcPointResult<C> {
-    /// Multiply a batch of `MpcPointResult<C>`s with a batch of `MpcScalarResult`s
+    /// Multiply a batch of `MpcPointResult`s with a batch of `MpcScalarResult`s
     #[allow(non_snake_case)]
     pub fn batch_mul(a: &[MpcScalarResult<C>], b: &[MpcPointResult<C>]) -> Vec<MpcPointResult<C>> {
         assert_eq!(a.len(), b.len(), "Batch add requires equal length inputs");

--- a/src/algebra/mpc_curve.rs
+++ b/src/algebra/mpc_curve.rs
@@ -41,14 +41,14 @@ impl<C: CurveGroup> MpcPointResult<C> {
     }
 
     /// Borrow the fabric that this result is allocated in
-    pub fn fabric(&self) -> &MpcFabric {
+    pub fn fabric(&self) -> &MpcFabric<C> {
         self.share.fabric()
     }
 
     /// Open the value; both parties send their shares to the counterparty
     pub fn open(&self) -> CurvePointResult<C> {
         let send_my_share =
-            |args: Vec<ResultValue>| NetworkPayload::Point(args[0].to_owned().into());
+            |args: Vec<ResultValue<C>>| NetworkPayload::Point(args[0].to_owned().into());
 
         // Party zero sends first then receives
         let (share0, share1): (CurvePointResult<C>, CurvePointResult<C>) =
@@ -76,7 +76,7 @@ impl<C: CurveGroup> MpcPointResult<C> {
         let n = values.len();
         let fabric = &values[0].fabric();
         let all_ids = values.iter().map(|v| v.id()).collect_vec();
-        let send_my_shares = |args: Vec<ResultValue>| {
+        let send_my_shares = |args: Vec<ResultValue<C>>| {
             NetworkPayload::PointBatch(args.into_iter().map(|arg| arg.into()).collect_vec())
         };
 
@@ -444,8 +444,8 @@ impl<C: CurveGroup> Mul<&ScalarResult<C>> for &MpcPointResult<C> {
     fn mul(self, rhs: &ScalarResult<C>) -> Self::Output {
         self.fabric()
             .new_gate_op(vec![self.id(), rhs.id()], |mut args| {
-                let lhs: CurvePoint = args.remove(0).into();
-                let rhs: Scalar = args.remove(0).into();
+                let lhs: CurvePoint<C> = args.remove(0).into();
+                let rhs: Scalar<C> = args.remove(0).into();
 
                 ResultValue::Point(lhs * rhs)
             })

--- a/src/algebra/mpc_scalar.rs
+++ b/src/algebra/mpc_scalar.rs
@@ -33,7 +33,7 @@ impl<C: CurveGroup> From<ScalarResult<C>> for MpcScalarResult<C> {
     }
 }
 
-/// Defines the result handle type that represents a future result of an `MpcScalarResult<C>`
+/// Defines the result handle type that represents a future result of an `MpcScalar`
 impl<C: CurveGroup> MpcScalarResult<C> {
     /// Creates an MPC scalar from a given underlying scalar assumed to be a secret share
     pub fn new_shared(value: ScalarResult<C>) -> MpcScalarResult<C> {
@@ -199,7 +199,7 @@ impl<C: CurveGroup> Add<&MpcScalarResult<C>> for &MpcScalarResult<C> {
 impl_borrow_variants!(MpcScalarResult<C>, Add, add, +, MpcScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> MpcScalarResult<C> {
-    /// Add two batches of `MpcScalarResult<C>`s using a single batched gate
+    /// Add two batches of `MpcScalarResult`s using a single batched gate
     pub fn batch_add(
         a: &[MpcScalarResult<C>],
         b: &[MpcScalarResult<C>],
@@ -230,7 +230,7 @@ impl<C: CurveGroup> MpcScalarResult<C> {
         scalars.into_iter().map(|s| s.into()).collect_vec()
     }
 
-    /// Add a batch of `MpcScalarResult<C>`s to a batch of public `ScalarResult<C>`s
+    /// Add a batch of `MpcScalarResult`s to a batch of public `ScalarResult`s
     pub fn batch_add_public(
         a: &[MpcScalarResult<C>],
         b: &[ScalarResult<C>],
@@ -364,7 +364,7 @@ impl<C: CurveGroup> Sub<&MpcScalarResult<C>> for &MpcScalarResult<C> {
 impl_borrow_variants!(MpcScalarResult<C>, Sub, sub, -, MpcScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> MpcScalarResult<C> {
-    /// Subtract two batches of `MpcScalarResult<C>`s using a single batched gate
+    /// Subtract two batches of `MpcScalarResult`s using a single batched gate
     pub fn batch_sub(
         a: &[MpcScalarResult<C>],
         b: &[MpcScalarResult<C>],
@@ -400,7 +400,7 @@ impl<C: CurveGroup> MpcScalarResult<C> {
         scalars.into_iter().map(|s| s.into()).collect_vec()
     }
 
-    /// Subtract a batch of `MpcScalarResult<C>`s from a batch of public `ScalarResult<C>`s
+    /// Subtract a batch of `MpcScalarResult`s from a batch of public `ScalarResult`s
     pub fn batch_sub_public(
         a: &[MpcScalarResult<C>],
         b: &[ScalarResult<C>],
@@ -543,7 +543,7 @@ impl<C: CurveGroup> Mul<&MpcScalarResult<C>> for &MpcScalarResult<C> {
 impl_borrow_variants!(MpcScalarResult<C>, Mul, mul, *, MpcScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> MpcScalarResult<C> {
-    /// Multiply a batch of `MpcScalarResult<C>s` over a single network op
+    /// Multiply a batch of `MpcScalarResult`s over a single network op
     pub fn batch_mul(
         a: &[MpcScalarResult<C>],
         b: &[MpcScalarResult<C>],
@@ -578,7 +578,7 @@ impl<C: CurveGroup> MpcScalarResult<C> {
         MpcScalarResult::batch_add(&de_plus_db, &ea_plus_c)
     }
 
-    /// Multiply a batch of `MpcScalarResult<C>`s by a batch of public `ScalarResult<C>`s
+    /// Multiply a batch of `MpcScalarResult`s by a batch of public `ScalarResult`s
     pub fn batch_mul_public(
         a: &[MpcScalarResult<C>],
         b: &[ScalarResult<C>],

--- a/src/algebra/scalar.rs
+++ b/src/algebra/scalar.rs
@@ -1,4 +1,4 @@
-//! Defines the scalar types that form the basis of the Starknet algebra
+//! Defines the scalar types that form the basis of the MPC algebra
 
 // ----------------------------
 // | Scalar Field Definitions |
@@ -143,9 +143,9 @@ impl<'de, C: CurveGroup> Deserialize<'de> for Scalar<C> {
 
 // === Addition === //
 
-/// A type alias for a result that resolves to a `Scalar<C>`
+/// A type alias for a result that resolves to a `Scalar`
 pub type ScalarResult<C> = ResultHandle<C, Scalar<C>>;
-/// A type alias for a result that resolves to a batch of `Scalar<C>`s
+/// A type alias for a result that resolves to a batch of `Scalar`s
 pub type BatchScalarResult<C> = ResultHandle<C, Vec<Scalar<C>>>;
 impl<C: CurveGroup> ScalarResult<C> {
     /// Compute the multiplicative inverse of the scalar in its field
@@ -275,7 +275,7 @@ impl<C: CurveGroup> Sub<&ScalarResult<C>> for &ScalarResult<C> {
 impl_borrow_variants!(ScalarResult<C>, Sub, sub, -, ScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> ScalarResult<C> {
-    /// Subtract two batches of `ScalarResult<C>`s
+    /// Subtract two batches of `ScalarResult`s
     pub fn batch_sub(a: &[ScalarResult<C>], b: &[ScalarResult<C>]) -> Vec<ScalarResult<C>> {
         assert_eq!(a.len(), b.len(), "Batch sub requires equal length inputs");
 
@@ -343,7 +343,7 @@ impl<C: CurveGroup> Mul<&ScalarResult<C>> for &ScalarResult<C> {
 impl_borrow_variants!(ScalarResult<C>, Mul, mul, *, ScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> ScalarResult<C> {
-    /// Multiply two batches of `ScalarResult<C>`s
+    /// Multiply two batches of `ScalarResult`s
     pub fn batch_mul(a: &[ScalarResult<C>], b: &[ScalarResult<C>]) -> Vec<ScalarResult<C>> {
         assert_eq!(a.len(), b.len(), "Batch mul requires equal length inputs");
 
@@ -385,7 +385,7 @@ impl<C: CurveGroup> Neg for &ScalarResult<C> {
 impl_borrow_variants!(ScalarResult<C>, Neg, neg, -, C: CurveGroup);
 
 impl<C: CurveGroup> ScalarResult<C> {
-    /// Negate a batch of `ScalarResult<C>`s
+    /// Negate a batch of `ScalarResult`s
     pub fn batch_neg(a: &[ScalarResult<C>]) -> Vec<ScalarResult<C>> {
         let n = a.len();
         let fabric = &a[0].fabric;

--- a/src/algebra/scalar.rs
+++ b/src/algebra/scalar.rs
@@ -63,8 +63,6 @@ impl<C: CurveGroup> Scalar<C> {
     }
 
     /// Sample a random field element
-    ///
-    /// TODO: Validate that this gives a uniform distribution over the field
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         Self(C::ScalarField::rand(rng))
     }

--- a/src/algebra/scalar.rs
+++ b/src/algebra/scalar.rs
@@ -12,6 +12,7 @@ use std::{
 
 use ark_ec::CurveGroup;
 use ark_ff::{batch_inversion, Field, PrimeField};
+use ark_std::UniformRand;
 use itertools::Itertools;
 use num_bigint::BigUint;
 use rand::{CryptoRng, RngCore};
@@ -65,11 +66,7 @@ impl<C: CurveGroup> Scalar<C> {
     ///
     /// TODO: Validate that this gives a uniform distribution over the field
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
-        let mut random_bytes = vec![0u8; n_bytes_field::<C::ScalarField>()];
-        rng.fill_bytes(&mut random_bytes);
-
-        let val = C::ScalarField::from_random_bytes(&random_bytes).unwrap();
-        Self(val)
+        Self(C::ScalarField::rand(rng))
     }
 
     /// Compute the multiplicative inverse of the scalar in its field

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -1,13 +1,14 @@
 //! Defines Pedersen commitments over the Stark curve used to commit to a value
 //! before opening it
 
+use ark_ec::CurveGroup;
 use rand::thread_rng;
 use sha3::{Digest, Sha3_256};
 
 use crate::{
     algebra::{
+        curve::{CurvePoint, CurvePointResult},
         scalar::{Scalar, ScalarResult},
-        stark_curve::{StarkPoint, StarkPointResult},
     },
     fabric::ResultValue,
 };
@@ -15,19 +16,19 @@ use crate::{
 /// A handle on the result of a Pedersen commitment, including the committed secret
 ///
 /// Of the form `value * G + blinder * H`
-pub(crate) struct PedersenCommitment {
+pub(crate) struct PedersenCommitment<C: CurveGroup> {
     /// The committed value
-    pub(crate) value: Scalar,
+    pub(crate) value: Scalar<C>,
     /// The commitment blinder
-    pub(crate) blinder: Scalar,
+    pub(crate) blinder: Scalar<C>,
     /// The value of the commitment
-    pub(crate) commitment: StarkPoint,
+    pub(crate) commitment: CurvePoint<C>,
 }
 
-impl PedersenCommitment {
+impl<C: CurveGroup> PedersenCommitment<C> {
     /// Verify that the given commitment is valid
     pub(crate) fn verify(&self) -> bool {
-        let generator = StarkPoint::generator();
+        let generator = CurvePoint::generator();
         let commitment = generator * self.value + generator * self.blinder;
 
         commitment == self.commitment
@@ -35,23 +36,23 @@ impl PedersenCommitment {
 }
 
 /// A Pedersen commitment that has been allocated in an MPC computation graph
-pub(crate) struct PedersenCommitmentResult {
+pub(crate) struct PedersenCommitmentResult<C: CurveGroup> {
     /// The committed value
-    pub(crate) value: ScalarResult,
+    pub(crate) value: ScalarResult<C>,
     /// The commitment blinder
-    pub(crate) blinder: Scalar,
+    pub(crate) blinder: Scalar<C>,
     /// The value of the commitment
-    pub(crate) commitment: StarkPointResult,
+    pub(crate) commitment: CurvePointResult<C>,
 }
 
-impl PedersenCommitmentResult {
+impl<C: CurveGroup> PedersenCommitmentResult<C> {
     /// Create a new Pedersen commitment to an underlying value
-    pub(crate) fn commit(value: ScalarResult) -> PedersenCommitmentResult {
+    pub(crate) fn commit(value: ScalarResult<C>) -> PedersenCommitmentResult<C> {
         // Concretely, we use the curve generator for both `G` and `H` as is done
         // in dalek-cryptography: https://github.com/dalek-cryptography/bulletproofs/blob/main/src/generators.rs#L44-L53
         let mut rng = thread_rng();
         let blinder = Scalar::random(&mut rng);
-        let generator = StarkPoint::generator();
+        let generator = CurvePoint::generator();
         let commitment = generator * &value + generator * blinder;
 
         PedersenCommitmentResult {
@@ -69,16 +70,16 @@ impl PedersenCommitmentResult {
 /// We use hash commitments to commit to curve points before opening them. There is no straightforward
 /// way to adapt Pedersen commitments to curve points, and we do not need the homomorphic properties
 /// of a Pedersen commitment
-pub(crate) struct HashCommitment {
+pub(crate) struct HashCommitment<C: CurveGroup> {
     /// The committed value
-    pub(crate) value: StarkPoint,
+    pub(crate) value: CurvePoint<C>,
     /// The blinder used in the commitment
-    pub(crate) blinder: Scalar,
+    pub(crate) blinder: Scalar<C>,
     /// The value of the commitment
-    pub(crate) commitment: Scalar,
+    pub(crate) commitment: Scalar<C>,
 }
 
-impl HashCommitment {
+impl<C: CurveGroup> HashCommitment<C> {
     /// Verify that the given commitment is valid
     pub(crate) fn verify(&self) -> bool {
         // Create the bytes buffer
@@ -97,22 +98,22 @@ impl HashCommitment {
 }
 
 /// A hash commitment that has been allocated in an MPC computation graph
-pub(crate) struct HashCommitmentResult {
+pub(crate) struct HashCommitmentResult<C: CurveGroup> {
     /// The committed value
-    pub(crate) value: StarkPointResult,
+    pub(crate) value: CurvePointResult<C>,
     /// The blinder used in the commitment
-    pub(crate) blinder: Scalar,
+    pub(crate) blinder: Scalar<C>,
     /// The value of the commitment
-    pub(crate) commitment: ScalarResult,
+    pub(crate) commitment: ScalarResult<C>,
 }
 
-impl HashCommitmentResult {
+impl<C: CurveGroup> HashCommitmentResult<C> {
     /// Create a new hash commitment to an underlying value
-    pub(crate) fn commit(value: StarkPointResult) -> HashCommitmentResult {
+    pub(crate) fn commit(value: CurvePointResult<C>) -> HashCommitmentResult<C> {
         let mut rng = thread_rng();
         let blinder = Scalar::random(&mut rng);
         let comm = value.fabric.new_gate_op(vec![value.id], move |mut args| {
-            let value: StarkPoint = args.remove(0).into();
+            let value: CurvePoint<C> = args.remove(0).into();
 
             // Create the bytes buffer
             let mut bytes = value.to_bytes();

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -1,4 +1,4 @@
-//! Defines Pedersen commitments over the Stark curve used to commit to a value
+//! Defines Pedersen commitments over the system curve used to commit to a value
 //! before opening it
 
 use ark_ec::CurveGroup;

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -540,17 +540,17 @@ impl<C: CurveGroup> MpcFabric<C> {
         (0..n).map(|_| val.clone()).collect_vec()
     }
 
-    /// Get the hardcoded curve identity wire as a raw `StarkPoint`
+    /// Get the hardcoded curve identity wire as a raw `CurvePointResult`
     pub fn curve_identity(&self) -> CurvePointResult<C> {
         ResultHandle::new(self.inner.curve_identity(), self.clone())
     }
 
-    /// Get the hardcoded shared curve identity wire as an `MpcStarkPointResult`
+    /// Get the hardcoded shared curve identity wire as an `MpcPointResult`
     fn curve_identity_shared(&self) -> MpcPointResult<C> {
         MpcPointResult::new_shared(self.curve_identity())
     }
 
-    /// Get the hardcoded curve identity wire as an `AuthenticatedStarkPointResult`
+    /// Get the hardcoded curve identity wire as an `AuthenticatedPointResult`
     ///
     /// Both parties hold the identity point directly in this case
     pub fn curve_identity_authenticated(&self) -> AuthenticatedPointResult<C> {
@@ -633,7 +633,7 @@ impl<C: CurveGroup> MpcFabric<C> {
         AuthenticatedScalarResult::new_shared_from_batch_result(shares, n)
     }
 
-    /// Share a `StarkPoint` value with the counterparty
+    /// Share a `CurvePoint` value with the counterparty
     pub fn share_point(&self, val: CurvePoint<C>, sender: PartyId) -> AuthenticatedPointResult<C> {
         let point: CurvePointResult<C> = if self.party_id() == sender {
             // As mentioned in https://eprint.iacr.org/2009/226.pdf
@@ -657,7 +657,7 @@ impl<C: CurveGroup> MpcFabric<C> {
         AuthenticatedPointResult::new_shared(point)
     }
 
-    /// Share a batch of `StarkPoint`s with the counterparty
+    /// Share a batch of `CurvePoint`s with the counterparty
     pub fn batch_share_point(
         &self,
         vals: Vec<CurvePoint<C>>,

--- a/src/fabric/executor.rs
+++ b/src/fabric/executor.rs
@@ -5,6 +5,9 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
+#[cfg(feature = "stats")]
+use std::fmt::{Formatter, Result as FmtResult};
+
 use ark_ec::CurveGroup;
 use crossbeam::queue::SegQueue;
 use itertools::Itertools;
@@ -63,7 +66,7 @@ impl ExecutorStats {
     }
 
     /// Add an operation to the executor's depth map
-    pub fn new_operation(&mut self, op: &Operation, from_network_op: bool) {
+    pub fn new_operation<C: CurveGroup>(&mut self, op: &Operation<C>, from_network_op: bool) {
         let max_dep = op
             .args
             .iter()
@@ -274,7 +277,7 @@ impl<C: CurveGroup> Executor<C> {
 
     /// Record the depth of an operation in the circuit
     #[cfg(feature = "stats")]
-    fn record_op_depth(&mut self, op: &Operation) {
+    fn record_op_depth(&mut self, op: &Operation<C>) {
         let is_network_op = matches!(op.op_type, OperationType::Network { .. });
         self.stats.new_operation(op, is_network_op);
     }

--- a/src/fabric/network_sender.rs
+++ b/src/fabric/network_sender.rs
@@ -40,6 +40,7 @@ pub struct NetworkStats {
     pub messages_received: AtomicUsize,
 }
 
+#[allow(unused)]
 impl NetworkStats {
     /// Increment the number of bytes sent
     pub fn increment_bytes_sent(&self, bytes: usize) {
@@ -140,7 +141,7 @@ impl<C: CurveGroup, N: MpcNetwork<C> + 'static> NetworkSender<C, N> {
     async fn read_loop(
         mut network_stream: SplitStream<N>,
         result_queue: Arc<SegQueue<ExecutorMessage<C>>>,
-        stats: Arc<NetworkStats>,
+        #[allow(unused)] stats: Arc<NetworkStats>,
     ) -> MpcNetworkError {
         while let Some(Ok(msg)) = network_stream.next().await {
             #[cfg(feature = "stats")]
@@ -164,7 +165,7 @@ impl<C: CurveGroup, N: MpcNetwork<C> + 'static> NetworkSender<C, N> {
     async fn write_loop(
         outbound_stream: KanalReceiver<NetworkOutbound<C>>,
         mut network: SplitSink<N, NetworkOutbound<C>>,
-        stats: Arc<NetworkStats>,
+        #[allow(unused)] stats: Arc<NetworkStats>,
     ) -> MpcNetworkError {
         while let Ok(msg) = outbound_stream.recv().await {
             #[cfg(feature = "stats")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,11 +58,15 @@ pub mod test_helpers {
     use futures::Future;
 
     use crate::{
-        algebra::test_helper::TestCurve,
         beaver::PartyIDBeaverSource,
         network::{MockNetwork, NoRecvNetwork, UnboundedDuplexStream},
         MpcFabric, PARTY0, PARTY1,
     };
+
+    use ark_curve25519::EdwardsProjective as Curve25519Projective;
+
+    /// A curve used for testing algebra implementations, set to curve25519
+    pub type TestCurve = Curve25519Projective;
 
     /// Create a mock fabric
     pub fn mock_fabric() -> MpcFabric<TestCurve> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,16 +7,11 @@
 //! Defines an MPC implementation over the Stark curve that allows for out-of-order execution of
 //! the underlying MPC circuit
 
-use std::{
-    cell::RefCell,
-    rc::Rc,
-    sync::{Arc, RwLock},
-};
+use std::sync::{Arc, RwLock};
 
-use algebra::{scalar::Scalar, stark_curve::StarkPoint};
-use beaver::SharedValueSource;
+use algebra::{curve::CurvePoint, scalar::Scalar};
+use ark_ec::CurveGroup;
 
-use network::MpcNetwork;
 use rand::thread_rng;
 
 pub mod algebra;
@@ -45,9 +40,9 @@ pub const PARTY1: u64 = 1;
 
 /// Generate a random curve point by multiplying a random scalar with the
 /// Stark curve group generator
-pub fn random_point() -> StarkPoint {
+pub fn random_point<C: CurveGroup>() -> CurvePoint<C> {
     let mut rng = thread_rng();
-    StarkPoint::generator() * Scalar::random(&mut rng)
+    CurvePoint::generator() * Scalar::random(&mut rng)
 }
 
 // --------------------
@@ -57,27 +52,20 @@ pub fn random_point() -> StarkPoint {
 /// A type alias for a shared locked value
 type Shared<T> = Arc<RwLock<T>>;
 
-/// SharedNetwork wraps a network implementation in a borrow-safe container
-/// while providing interior mutability
-#[allow(type_alias_bounds)]
-pub type SharedNetwork<N: MpcNetwork + Send> = Rc<RefCell<N>>;
-/// A type alias for a shared, mutable reference to an underlying beaver source
-#[allow(type_alias_bounds)]
-pub type BeaverSource<S: SharedValueSource> = Rc<RefCell<S>>;
-
 #[cfg(any(test, feature = "test_helpers"))]
 pub mod test_helpers {
     //! Defines test helpers for use in unit and integration tests, as well as benchmarks
     use futures::Future;
 
     use crate::{
+        algebra::test_helper::TestCurve,
         beaver::PartyIDBeaverSource,
         network::{MockNetwork, NoRecvNetwork, UnboundedDuplexStream},
         MpcFabric, PARTY0, PARTY1,
     };
 
     /// Create a mock fabric
-    pub fn mock_fabric() -> MpcFabric {
+    pub fn mock_fabric() -> MpcFabric<TestCurve> {
         let network = NoRecvNetwork::default();
         let beaver_source = PartyIDBeaverSource::default();
 
@@ -93,7 +81,7 @@ pub mod test_helpers {
     where
         T: Send + 'static,
         S: Future<Output = T> + Send + 'static,
-        F: FnMut(MpcFabric) -> S,
+        F: FnMut(MpcFabric<TestCurve>) -> S,
     {
         // Build a duplex stream to broker communication between the two parties
         let (party0_stream, party1_stream) = UnboundedDuplexStream::new_duplex_pair();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(incomplete_features)]
 #![feature(inherent_associated_types)]
 
-//! Defines an MPC implementation over the Stark curve that allows for out-of-order execution of
+//! Defines an MPC implementation over the a generic Arkworks curve that allows for out-of-order execution of
 //! the underlying MPC circuit
 
 use std::sync::{Arc, RwLock};
@@ -39,7 +39,7 @@ pub const PARTY0: u64 = 0;
 pub const PARTY1: u64 = 1;
 
 /// Generate a random curve point by multiplying a random scalar with the
-/// Stark curve group generator
+/// curve group generator
 pub fn random_point<C: CurveGroup>() -> CurvePoint<C> {
     let mut rng = thread_rng();
     CurvePoint::generator() * Scalar::random(&mut rng)

--- a/src/network/quic.rs
+++ b/src/network/quic.rs
@@ -277,7 +277,7 @@ where
 {
     type Item = Result<NetworkOutbound<C>, MpcNetworkError>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Box::pin(self.get_mut().receive_message())
             .as_mut()
             .poll(cx)
@@ -291,7 +291,7 @@ where
 {
     type Error = MpcNetworkError;
 
-    fn start_send(mut self: Pin<&mut Self>, msg: NetworkOutbound<C>) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, msg: NetworkOutbound<C>) -> Result<(), Self::Error> {
         if !self.connected {
             return Err(MpcNetworkError::NetworkUninitialized);
         }


### PR DESCRIPTION
### Purpose
This PR makes the rest of the crate generic over the curve type; following up on #19.

### Todo
- Tests and Benchmarks
- Update comments throughout the crate

### Testing
- Tests fail in the current intermediate state