### PR TITLE
meta: Cleanup crate, comments, README, etc after curve generics refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-name = "mpc-stark"
-version = "0.2.4"
+name = "ark-mpc"
+version = "0.1.0"
 description = "Malicious-secure SPDZ style two party secure computation"
 keywords = ["mpc", "crypto", "cryptography"]
 homepage = "https://renegade.fi"
 authors = ["Joey Kraut <joey@renegade.fi>"]
 edition = "2021"
 readme = "README.md"
-repository = "https://github.com/renegade-fi/mpc-ristretto"
+repository = "https://github.com/renegade-fi/ark-mpc"
 license = "MIT OR Apache-2.0"
 
 [lib]
-name = "mpc_stark"
+name = "ark_mpc"
 path = "src/lib.rs"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -1,27 +1,30 @@
-# MPC-Stark
+# `ark-mpc`
 <div>
   <img
-    src="https://github.com/renegade-fi/mpc-stark/actions/workflows/test.yml/badge.svg"
+    src="https://github.com/renegade-fi/ark-mpc/actions/workflows/test.yml/badge.svg"
   />
   <img
-    src="https://github.com/renegade-fi/mpc-stark/actions/workflows/clippy.yml/badge.svg"
+    src="https://github.com/renegade-fi/ark-mpc/actions/workflows/clippy.yml/badge.svg"
   />
   <img
-    src="https://github.com/renegade-fi/mpc-stark/actions/workflows/rustfmt.yml/badge.svg"
+    src="https://github.com/renegade-fi/ark-mpc/actions/workflows/rustfmt.yml/badge.svg"
   />
   <img
-    src="https://img.shields.io/crates/v/mpc-stark"
+    src="https://img.shields.io/crates/v/ark-mpc"
   />
 </div>
 
 ## Example
-`mpc-stark` provides a malicious secure [SPDZ](https://eprint.iacr.org/2011/535.pdf) style framework for two party secure computation. The circuit is constructed on the fly, by overloading arithmetic operators of MPC types, see the example below in which each of the parties shares a value and together they compute the product:
+`ark-mpc` provides a malicious secure [SPDZ](https://eprint.iacr.org/2011/535.pdf) style framework for two party secure computation. The circuit is constructed on the fly, by overloading arithmetic operators of MPC types, see the example below in which each of the parties shares a value and together they compute the product:
 ```rust
-use mpc_stark::{
+use ark_mpc::{
     algebra::scalar::Scalar, beaver::SharedValueSource, network::QuicTwoPartyNet, MpcFabric,
     PARTY0, PARTY1,
 };
+use ark_curve25519::EdwardsProjective as Curve25519Projective;
 use rand::thread_rng;
+
+type Curve = Curve25519Projective;
 
 #[tokio::main]
 async fn main() {
@@ -34,7 +37,7 @@ async fn main() {
 
     // MPC circuit
     let mut rng = thread_rng();
-    let my_val = Scalar::random(&mut rng);
+    let my_val = Scalar::<Curve>::random(&mut rng);
     let fabric = MpcFabric::new(network, beaver);
 
     let a = fabric.share_scalar(my_val, PARTY0 /* sender */); // party0 value
@@ -50,7 +53,7 @@ async fn main() {
 ## Tests
 Unit tests for isolated parts of the library are available via
 ```bash
-cargo test --lib
+cargo test --lib --all-features
 ```
 
 The bulk of this library's testing is best done with real communication; and so most of the tests are integration tests. The integration tests can be run as

--- a/benches/circuit_msm_throughput.rs
+++ b/benches/circuit_msm_throughput.rs
@@ -2,11 +2,11 @@
 
 use std::time::{Duration, Instant};
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::authenticated_curve::AuthenticatedPointResult, test_helpers::execute_mock_mpc,
 };
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use itertools::Itertools;
 use tokio::runtime::Builder as RuntimeBuilder;
 
 /// Measure the throughput and latency of a variable-sized MSM

--- a/benches/circuit_mul_throughput.rs
+++ b/benches/circuit_mul_throughput.rs
@@ -2,8 +2,8 @@
 
 use std::time::{Duration, Instant};
 
+use ark_mpc::{test_helpers::execute_mock_mpc, PARTY0};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use mpc_stark::{test_helpers::execute_mock_mpc, PARTY0};
 use tokio::runtime::Builder as RuntimeBuilder;
 
 /// Measure the throughput and latency of a set of sequential multiplication gates

--- a/benches/gate_throughput.rs
+++ b/benches/gate_throughput.rs
@@ -1,13 +1,13 @@
 use std::{path::Path, sync::Mutex};
 
+use ark_mpc::{
+    algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork,
+    test_helpers::TestCurve, MpcFabric, PARTY0,
+};
 use cpuprofiler::{Profiler as CpuProfiler, PROFILER};
 use criterion::{
     criterion_group, criterion_main, profiler::Profiler as CriterionProfiler, BenchmarkId,
     Criterion, Throughput,
-};
-use mpc_stark::{
-    algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork,
-    test_helpers::TestCurve, MpcFabric, PARTY0,
 };
 use rand::{rngs::OsRng, thread_rng};
 use tokio::runtime::Builder as RuntimeBuilder;

--- a/benches/gate_throughput_traced.rs
+++ b/benches/gate_throughput_traced.rs
@@ -3,13 +3,13 @@
 
 use std::time::Instant;
 
-use clap::Parser;
-use cpuprofiler::PROFILER;
-use gperftools::HEAP_PROFILER;
-use mpc_stark::{
+use ark_mpc::{
     algebra::scalar::Scalar, beaver::PartyIDBeaverSource, network::NoRecvNetwork,
     test_helpers::TestCurve, MpcFabric, PARTY0,
 };
+use clap::Parser;
+use cpuprofiler::PROFILER;
+use gperftools::HEAP_PROFILER;
 use rand::thread_rng;
 
 // -----------

--- a/benches/growable_buffer.rs
+++ b/benches/growable_buffer.rs
@@ -1,5 +1,5 @@
+use ark_mpc::{algebra::scalar::Scalar, buffer::GrowableBuffer, test_helpers::TestCurve};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use mpc_stark::{algebra::scalar::Scalar, buffer::GrowableBuffer, test_helpers::TestCurve};
 
 // --------------
 // | Benchmarks |

--- a/benches/native_msm.rs
+++ b/benches/native_msm.rs
@@ -1,12 +1,12 @@
-//! Defines a benchmark for native multiscalar-multiplication on `Scalar` and `StarkPoint` types
+//! Defines a benchmark for native multiscalar-multiplication on `Scalar` and `CurvePoint` types
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{curve::CurvePoint, scalar::Scalar},
     random_point,
     test_helpers::TestCurve,
 };
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use itertools::Itertools;
 use rand::thread_rng;
 
 /// The maximum power of two to scale the MSM benchmark to

--- a/benches/test_stats.rs
+++ b/benches/test_stats.rs
@@ -1,6 +1,6 @@
 //! A simple benchmark for testing that stats collection is properly working
 
-use mpc_stark::{algebra::scalar::Scalar, test_helpers::execute_mock_mpc, PARTY0, PARTY1};
+use ark_mpc::{algebra::scalar::Scalar, test_helpers::execute_mock_mpc, PARTY0, PARTY1};
 use rand::{distributions::uniform::SampleRange, thread_rng};
 
 #[tokio::main]

--- a/integration/authenticated_curve.rs
+++ b/integration/authenticated_curve.rs
@@ -1,7 +1,6 @@
-//! Integration tests for the `AuthenticatedStarkPoint` type
+//! Integration tests for the `AuthenticatedPointResult` type
 
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         authenticated_curve::{
             test_helpers::{modify_mac, modify_public_modifier, modify_share},
@@ -11,6 +10,7 @@ use mpc_stark::{
     },
     random_point, PARTY0, PARTY1,
 };
+use itertools::Itertools;
 use rand::thread_rng;
 
 use crate::{
@@ -151,7 +151,7 @@ fn test_batch_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(res_open, expected_result)
 }
 
-/// Test addition between a batch of `AuthenticatedStarkPoint`s and `StarkPoint`s
+/// Test addition between a batch of `AuthenticatedPointResult`s and `CurvePoint`s
 fn test_batch_add_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -245,7 +245,7 @@ fn test_batch_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(res_open, expected_result)
 }
 
-/// Test addition between a batch of `AuthenticatedStarkPoint`s and `StarkPoint`s
+/// Test addition between a batch of `AuthenticatedPointResult`s and `CurvePoint`s
 fn test_batch_sub_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -384,7 +384,7 @@ fn test_batch_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(res_open, expected_result)
 }
 
-/// Test addition between a batch of `AuthenticatedStarkPoint`s and `StarkPoint`s
+/// Test addition between a batch of `AuthenticatedPointResult`s and `CurvePoint`s
 fn test_batch_mul_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -412,91 +412,91 @@ fn test_batch_mul_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
 }
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_open_authenticated",
+    name: "authenticated_curve_point::test_open_authenticated",
     test_fn: test_open_authenticated
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_open_authenticated__bad_mac",
+    name: "authenticated_curve_point::test_open_authenticated__bad_mac",
     test_fn: test_open_authenticated__bad_mac
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_open_authenticated__bad_share",
+    name: "authenticated_curve_point::test_open_authenticated__bad_share",
     test_fn: test_open_authenticated__bad_share
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_open_authenticated__bad_public_modifier",
+    name: "authenticated_curve_point::test_open_authenticated__bad_public_modifier",
     test_fn: test_open_authenticated__bad_public_modifier
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_addition_public_point",
+    name: "authenticated_curve_point::test_addition_public_point",
     test_fn: test_addition_public_point
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_add",
+    name: "authenticated_curve_point::test_add",
     test_fn: test_add
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_add",
+    name: "authenticated_curve_point::test_batch_add",
     test_fn: test_batch_add
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_add_public",
+    name: "authenticated_curve_point::test_batch_add_public",
     test_fn: test_batch_add_public
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_sub_public_point",
+    name: "authenticated_curve_point::test_sub_public_point",
     test_fn: test_sub_public_point
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_sub",
+    name: "authenticated_curve_point::test_sub",
     test_fn: test_sub
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_sub",
+    name: "authenticated_curve_point::test_batch_sub",
     test_fn: test_batch_sub
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_sub_public",
+    name: "authenticated_curve_point::test_batch_sub_public",
     test_fn: test_batch_sub_public
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_negation",
+    name: "authenticated_curve_point::test_negation",
     test_fn: test_negation
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_negation",
+    name: "authenticated_curve_point::test_batch_negation",
     test_fn: test_batch_negation
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_multiplication_public_scalar",
+    name: "authenticated_curve_point::test_multiplication_public_scalar",
     test_fn: test_multiplication_public_scalar
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_multiplication",
+    name: "authenticated_curve_point::test_multiplication",
     test_fn: test_multiplication
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_mul",
+    name: "authenticated_curve_point::test_batch_mul",
     test_fn: test_batch_mul
 });
 
 inventory::submit!(IntegrationTest {
-    name: "authenticated_stark_point::test_batch_mul_public",
+    name: "authenticated_curve_point::test_batch_mul_public",
     test_fn: test_batch_mul_public
 });

--- a/integration/authenticated_scalar.rs
+++ b/integration/authenticated_scalar.rs
@@ -1,14 +1,14 @@
-//! Integration tests for arithmetic on the `AuthenticatedScalar` type which provides
+//! Integration tests for arithmetic on the `AuthenticatedScalarResult` type which provides
 //! a malicious-secure primitive
 
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         authenticated_scalar::{test_helpers::*, AuthenticatedScalarResult},
         scalar::Scalar,
     },
     ResultValue, PARTY0, PARTY1,
 };
+use itertools::Itertools;
 use rand::thread_rng;
 use std::ops::Neg;
 

--- a/integration/circuits.rs
+++ b/integration/circuits.rs
@@ -1,13 +1,13 @@
 //! Tests for more complicated operations (i.e. circuits)
 
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         authenticated_curve::AuthenticatedPointResult,
         authenticated_scalar::AuthenticatedScalarResult, scalar::Scalar,
     },
     random_point, PARTY0, PARTY1,
 };
+use itertools::Itertools;
 use rand::thread_rng;
 
 use crate::{

--- a/integration/fabric.rs
+++ b/integration/fabric.rs
@@ -1,6 +1,6 @@
 //! Defines tests for the fabric directly
 
-use mpc_stark::{algebra::scalar::Scalar, PARTY0, PARTY1};
+use ark_mpc::{algebra::scalar::Scalar, PARTY0, PARTY1};
 
 use crate::{
     helpers::{assert_scalars_eq, await_result, share_scalar},

--- a/integration/helpers.rs
+++ b/integration/helpers.rs
@@ -1,10 +1,8 @@
-//! Defines testing mocks
+//! Defines testing mocks and helpers for integration tests
 
 use std::fmt::Debug;
 
-use futures::{future::join_all, Future};
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         authenticated_curve::AuthenticatedPointResult,
         authenticated_scalar::AuthenticatedScalarResult, mpc_curve::MpcPointResult,
@@ -14,6 +12,8 @@ use mpc_stark::{
     network::{NetworkPayload, PartyId},
     {MpcFabric, ResultHandle, ResultValue},
 };
+use futures::{future::join_all, Future};
+use itertools::Itertools;
 use tokio::runtime::Handle;
 
 // -----------
@@ -147,7 +147,7 @@ pub(crate) fn share_point(
     sender: PartyId,
     test_args: &IntegrationTestArgs,
 ) -> MpcPointResult<TestCurve> {
-    // Share the point then cast to an `MpcStarkPoint`
+    // Share the point then cast to an `MpcPointResult`
     let authenticated_point = share_authenticated_point(value, sender, test_args);
     authenticated_point.mpc_share()
 }

--- a/integration/main.rs
+++ b/integration/main.rs
@@ -2,17 +2,17 @@ use std::{borrow::Borrow, io::Write, net::SocketAddr, process::exit, thread, tim
 
 use ark_curve25519::Curve25519Config;
 use ark_ec::twisted_edwards::Projective;
+use ark_mpc::{
+    algebra::{curve::CurvePoint, scalar::Scalar},
+    network::{NetworkOutbound, NetworkPayload, QuicTwoPartyNet},
+    MpcFabric, PARTY0,
+};
 use clap::Parser;
 use colored::Colorize;
 use dns_lookup::lookup_host;
 use env_logger::Builder;
 use futures::{SinkExt, StreamExt};
 use helpers::PartyIDBeaverSource;
-use mpc_stark::{
-    algebra::{curve::CurvePoint, scalar::Scalar},
-    network::{NetworkOutbound, NetworkPayload, QuicTwoPartyNet},
-    MpcFabric, PARTY0,
-};
 use tokio::runtime::{Builder as RuntimeBuilder, Handle};
 use tracing::log::{self, LevelFilter};
 

--- a/integration/mpc_curve.rs
+++ b/integration/mpc_curve.rs
@@ -1,7 +1,6 @@
-//! Defines tests for the `MpcStarkPoint` type and arithmetic on this type
+//! Defines tests for the `MpcPointResult` type and arithmetic on this type
 
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         curve::CurvePointResult,
         mpc_curve::MpcPointResult,
@@ -9,6 +8,7 @@ use mpc_stark::{
     },
     random_point, PARTY0, PARTY1,
 };
+use itertools::Itertools;
 use rand::thread_rng;
 
 use crate::{
@@ -20,7 +20,7 @@ use crate::{
     IntegrationTest, IntegrationTestArgs, TestCurve,
 };
 
-/// Test addition of `MpcStarkPoint` types
+/// Test addition of `MpcPointResult` types
 fn test_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let val = random_point();
     let my_value = test_args.fabric.allocate_point(val);
@@ -42,7 +42,7 @@ fn test_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test addition of `MpcStarkPoint` with `StarkPoint`
+/// Test addition of `MpcPointResult` with `CurvePoint`
 ///
 /// Party 0 chooses an MPC point and party 1 chooses a plaintext point
 fn test_add_point_constant(test_args: &IntegrationTestArgs) -> Result<(), String> {
@@ -67,7 +67,7 @@ fn test_add_point_constant(test_args: &IntegrationTestArgs) -> Result<(), String
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test adding a batch of `MpcStarkPoint` types
+/// Test adding a batch of `MpcPointResult` types
 fn test_batch_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -95,7 +95,7 @@ fn test_batch_add(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(opened_res, expected_result)
 }
 
-/// Tests addition between a batch of `MpcPointResult`s and `StarkPointResult`s
+/// Tests addition between a batch of `MpcPointResult`s and `CurvePointResult`s
 fn test_batch_add_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -120,7 +120,7 @@ fn test_batch_add_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
     assert_point_batches_eq(res_open, expected_result)
 }
 
-/// Test subtraction of `MpcStarkPoint` types
+/// Test subtraction of `MpcPointResult` types
 fn test_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let val = random_point();
     let my_value = test_args.fabric.allocate_point(val);
@@ -142,7 +142,7 @@ fn test_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test subtraction of `MpcStarkPoint` with `StarkPoint`
+/// Test subtraction of `MpcPointResult` with `PointResult`
 ///
 /// Party 0 chooses an MPC point and party 1 chooses a plaintext point
 fn test_sub_point_constant(test_args: &IntegrationTestArgs) -> Result<(), String> {
@@ -167,7 +167,7 @@ fn test_sub_point_constant(test_args: &IntegrationTestArgs) -> Result<(), String
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test subtracting a batch of `MpcStarkPoint` types
+/// Test subtracting a batch of `MpcPointResult` types
 fn test_batch_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -195,7 +195,7 @@ fn test_batch_sub(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(opened_res, expected_result)
 }
 
-/// Test subtracting a batch of `MpcStarkPoint` types and `StarkPointResult`s
+/// Test subtracting a batch of `MpcPointResult` types and `CurvePointResult`s
 fn test_batch_sub_public(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -220,7 +220,7 @@ fn test_batch_sub_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
     assert_point_batches_eq(res_open, expected_result)
 }
 
-/// Test negation of `MpcStarkPoint` types
+/// Test negation of `MpcPointResult` types
 fn test_neg(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let val = random_point();
     let my_value = test_args.fabric.allocate_point(val);
@@ -240,7 +240,7 @@ fn test_neg(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test negating a batch of `MpcStarkPoint` types
+/// Test negating a batch of `MpcPointResult` types
 fn test_batch_neg(test_args: &IntegrationTestArgs) -> Result<(), String> {
     let n = 10;
     let fabric = &test_args.fabric;
@@ -264,7 +264,7 @@ fn test_batch_neg(test_args: &IntegrationTestArgs) -> Result<(), String> {
     assert_point_batches_eq(opened_res, expected_result)
 }
 
-/// Test multiplication of an `MpcStarkPoint` type with an `MpcScalarResult` type
+/// Test multiplication of an `MpcPointResult` type with an `MpcScalarResult` type
 ///
 /// Party 0 chooses the point, party 1 chooses the scalar
 fn test_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
@@ -331,7 +331,7 @@ fn test_mul_scalar_constant(test_args: &IntegrationTestArgs) -> Result<(), Strin
     assert_points_eq(opened_res, expected_result)
 }
 
-/// Test multiplying a batch of `MpcStarkPoint` types
+/// Test multiplying a batch of `MpcPointResult` types
 ///
 /// Party 0 chooses the points and party 1 chooses the scalars
 fn test_batch_mul(test_args: &IntegrationTestArgs) -> Result<(), String> {
@@ -397,71 +397,71 @@ fn test_batch_mul_public(test_args: &IntegrationTestArgs) -> Result<(), String> 
 }
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_add",
+    name: "mpc_point::test_add",
     test_fn: test_add,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_add_point_constant",
+    name: "mpc_point::test_add_point_constant",
     test_fn: test_add_point_constant,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_add",
+    name: "mpc_point::test_batch_add",
     test_fn: test_batch_add,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_add_public",
+    name: "mpc_point::test_batch_add_public",
     test_fn: test_batch_add_public,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_sub",
+    name: "mpc_point::test_sub",
     test_fn: test_sub,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_sub_point_constant",
+    name: "mpc_point::test_sub_point_constant",
     test_fn: test_sub_point_constant,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_sub",
+    name: "mpc_point::test_batch_sub",
     test_fn: test_batch_sub,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_sub_public",
+    name: "mpc_point::test_batch_sub_public",
     test_fn: test_batch_sub_public,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_neg",
+    name: "mpc_point::test_neg",
     test_fn: test_neg,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_neg",
+    name: "mpc_point::test_batch_neg",
     test_fn: test_batch_neg,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_mul",
+    name: "mpc_point::test_mul",
     test_fn: test_mul,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_mul_scalar_constant",
+    name: "mpc_point::test_mul_scalar_constant",
     test_fn: test_mul_scalar_constant,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_mul",
+    name: "mpc_point::test_batch_mul",
     test_fn: test_batch_mul,
 });
 
 inventory::submit!(IntegrationTest {
-    name: "mpc_stark_point::test_batch_mul_public",
+    name: "mpc_point::test_batch_mul_public",
     test_fn: test_batch_mul_public,
 });

--- a/integration/mpc_scalar.rs
+++ b/integration/mpc_scalar.rs
@@ -1,12 +1,12 @@
 //! Defines unit tests for `MpcScalarResult` types
-use itertools::Itertools;
-use mpc_stark::{
+use ark_mpc::{
     algebra::{
         mpc_scalar::MpcScalarResult,
         scalar::{Scalar, ScalarResult},
     },
     PARTY0, PARTY1,
 };
+use itertools::Itertools;
 use rand::thread_rng;
 use std::ops::Neg;
 

--- a/src/algebra/authenticated_scalar.rs
+++ b/src/algebra/authenticated_scalar.rs
@@ -30,7 +30,7 @@ use super::{
 /// The number of results wrapped by an `AuthenticatedScalarResult<C>`
 pub const AUTHENTICATED_SCALAR_RESULT_LEN: usize = 3;
 
-/// A maliciously secure wrapper around an `MpcScalarResult<C>`, includes a MAC as per the
+/// A maliciously secure wrapper around an `MpcScalarResult`, includes a MAC as per the
 /// SPDZ protocol: https://eprint.iacr.org/2011/535.pdf
 /// that ensures security against a malicious adversary
 #[derive(Clone)]
@@ -42,7 +42,7 @@ pub struct AuthenticatedScalarResult<C: CurveGroup> {
     /// If the value is `x`, parties hold secret shares of the value
     /// \delta * x for the global MAC key `\delta`. The parties individually
     /// hold secret shares of this MAC key [\delta], so we can very naturally
-    /// extend the secret share arithmetic of the underlying `MpcScalarResult<C>` to
+    /// extend the secret share arithmetic of the underlying `MpcScalarResult` to
     /// the MAC updates as well
     pub(crate) mac: MpcScalarResult<C>,
     /// The public modifier tracks additions and subtractions of public values to the
@@ -65,7 +65,7 @@ impl<C: CurveGroup> Debug for AuthenticatedScalarResult<C> {
 impl<C: CurveGroup> AuthenticatedScalarResult<C> {
     /// Create a new result from the given shared value
     pub fn new_shared(value: ScalarResult<C>) -> Self {
-        // Create an `MpcScalarResult<C>` to represent the fact that this is a shared value
+        // Create an `MpcScalarResult` to represent the fact that this is a shared value
         let fabric = value.fabric.clone();
 
         let mpc_value = MpcScalarResult::new_shared(value);
@@ -113,7 +113,7 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
     /// Create a nwe shared batch of values from a batch network result
     ///
     /// The batch result combines the batch into one result, so it must be split out
-    /// first before creating the `AuthenticatedScalarResult<C>`s
+    /// first before creating the `AuthenticatedScalarResult`s
     pub fn new_shared_from_batch_result(
         values: BatchScalarResult<C>,
         n: usize,
@@ -130,13 +130,13 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
         Self::new_shared_batch(&scalar_results)
     }
 
-    /// Get the raw share as an `MpcScalarResult<C>`
+    /// Get the raw share as an `MpcScalarResult`
     #[cfg(feature = "test_helpers")]
     pub fn mpc_share(&self) -> MpcScalarResult<C> {
         self.share.clone()
     }
 
-    /// Get the raw share as a `ScalarResult<C>`
+    /// Get the raw share as a `ScalarResult`
     pub fn share(&self) -> ScalarResult<C> {
         self.share.to_scalar()
     }
@@ -162,7 +162,7 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
         MpcScalarResult::open_batch(&values.iter().map(|val| val.share.clone()).collect_vec())
     }
 
-    /// Convert a flattened iterator into a batch of `AuthenticatedScalarResult<C>`s
+    /// Convert a flattened iterator into a batch of `AuthenticatedScalarResult`s
     ///
     /// We assume that the iterator has been flattened in the same way order that `Self::id`s returns
     /// the `AuthenticatedScalar<C>`'s values: `[share, mac, public_modifier]`
@@ -387,7 +387,7 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
     }
 }
 
-/// The value that results from opening an `AuthenticatedScalarResult<C>` and checking its
+/// The value that results from opening an `AuthenticatedScalarResult` and checking its
 /// MAC. This encapsulates both the underlying value and the result of the MAC check
 #[derive(Clone)]
 pub struct AuthenticatedScalarOpenResult<C: CurveGroup> {
@@ -484,7 +484,7 @@ impl<C: CurveGroup> Add<&AuthenticatedScalarResult<C>> for &AuthenticatedScalarR
 impl_borrow_variants!(AuthenticatedScalarResult<C>, Add, add, +, AuthenticatedScalarResult<C>, Output=AuthenticatedScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> AuthenticatedScalarResult<C> {
-    /// Add two batches of `AuthenticatedScalarResult<C>`s
+    /// Add two batches of `AuthenticatedScalarResult`s
     pub fn batch_add(
         a: &[AuthenticatedScalarResult<C>],
         b: &[AuthenticatedScalarResult<C>],
@@ -533,11 +533,11 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
             },
         );
 
-        // Collect the gate results into a series of `AuthenticatedScalarResult<C>`s
+        // Collect the gate results into a series of `AuthenticatedScalarResult`s
         AuthenticatedScalarResult::from_flattened_iterator(gate_results.into_iter())
     }
 
-    /// Add a batch of `AuthenticatedScalarResult<C>`s to a batch of `ScalarResult<C>`s
+    /// Add a batch of `AuthenticatedScalarResult`s to a batch of `ScalarResult`s
     pub fn batch_add_public(
         a: &[AuthenticatedScalarResult<C>],
         b: &[ScalarResult<C>],
@@ -704,7 +704,7 @@ impl<C: CurveGroup> Sub<&AuthenticatedScalarResult<C>> for &AuthenticatedScalarR
 impl_borrow_variants!(AuthenticatedScalarResult<C>, Sub, sub, -, AuthenticatedScalarResult<C>, Output=AuthenticatedScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> AuthenticatedScalarResult<C> {
-    /// Add two batches of `AuthenticatedScalarResult<C>`s
+    /// Add two batches of `AuthenticatedScalarResult`s
     pub fn batch_sub(
         a: &[AuthenticatedScalarResult<C>],
         b: &[AuthenticatedScalarResult<C>],
@@ -753,11 +753,11 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
             },
         );
 
-        // Collect the gate results into a series of `AuthenticatedScalarResult<C>`s
+        // Collect the gate results into a series of `AuthenticatedScalarResult`s
         AuthenticatedScalarResult::from_flattened_iterator(gate_results.into_iter())
     }
 
-    /// Subtract a batch of `ScalarResult<C>`s from a batch of `AuthenticatedScalarResult<C>`s
+    /// Subtract a batch of `ScalarResult`s from a batch of `AuthenticatedScalarResult`s
     pub fn batch_sub_public(
         a: &[AuthenticatedScalarResult<C>],
         b: &[ScalarResult<C>],
@@ -813,7 +813,7 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
             },
         );
 
-        // Collect the gate results into a series of `AuthenticatedScalarResult<C>`s
+        // Collect the gate results into a series of `AuthenticatedScalarResult`s
         AuthenticatedScalarResult::from_flattened_iterator(gate_results.into_iter())
     }
 }
@@ -834,7 +834,7 @@ impl<C: CurveGroup> Neg for &AuthenticatedScalarResult<C> {
 impl_borrow_variants!(AuthenticatedScalarResult<C>, Neg, neg, -, C: CurveGroup);
 
 impl<C: CurveGroup> AuthenticatedScalarResult<C> {
-    /// Negate a batch of `AuthenticatedScalarResult<C>`s
+    /// Negate a batch of `AuthenticatedScalarResult`s
     pub fn batch_neg(a: &[AuthenticatedScalarResult<C>]) -> Vec<AuthenticatedScalarResult<C>> {
         if a.is_empty() {
             return vec![];
@@ -951,7 +951,7 @@ impl<C: CurveGroup> AuthenticatedScalarResult<C> {
         AuthenticatedScalarResult::batch_add(&de_plus_db, &ea_plus_c)
     }
 
-    /// Multiply a batch of `AuthenticatedScalarResult<C>`s by a batch of `ScalarResult<C>`s
+    /// Multiply a batch of `AuthenticatedScalarResult`s by a batch of `ScalarResult`s
     pub fn batch_mul_public(
         a: &[AuthenticatedScalarResult<C>],
         b: &[ScalarResult<C>],
@@ -1049,12 +1049,12 @@ pub mod test_helpers {
 
     use super::AuthenticatedScalarResult;
 
-    /// Modify the MAC of an `AuthenticatedScalarResult<C>`
+    /// Modify the MAC of an `AuthenticatedScalarResult`
     pub fn modify_mac<C: CurveGroup>(val: &mut AuthenticatedScalarResult<C>, new_value: Scalar<C>) {
         val.mac = val.fabric().allocate_scalar(new_value).into()
     }
 
-    /// Modify the underlying secret share of an `AuthenticatedScalarResult<C>`
+    /// Modify the underlying secret share of an `AuthenticatedScalarResult`
     pub fn modify_share<C: CurveGroup>(
         val: &mut AuthenticatedScalarResult<C>,
         new_value: Scalar<C>,
@@ -1062,7 +1062,7 @@ pub mod test_helpers {
         val.share = val.fabric().allocate_scalar(new_value).into()
     }
 
-    /// Modify the public modifier of an `AuthenticatedScalarResult<C>` by adding an offset
+    /// Modify the public modifier of an `AuthenticatedScalarResult` by adding an offset
     pub fn modify_public_modifier<C: CurveGroup>(
         val: &mut AuthenticatedScalarResult<C>,
         new_value: Scalar<C>,

--- a/src/algebra/mpc_curve.rs
+++ b/src/algebra/mpc_curve.rs
@@ -210,7 +210,7 @@ impl<C: CurveGroup> MpcPointResult<C> {
             .collect_vec()
     }
 
-    /// Add a batch of `MpcPointResult<C>s` to a batch of `CurvePointResult<C><C>`s
+    /// Add a batch of `MpcPointResults` to a batch of `CurvePointResult`s
     pub fn batch_add_public(
         a: &[MpcPointResult<C>],
         b: &[CurvePointResult<C>],
@@ -479,7 +479,7 @@ impl_borrow_variants!(MpcPointResult<C>, Mul, mul, *, MpcScalarResult<C>, C: Cur
 impl_commutative!(MpcPointResult<C>, Mul, mul, *, MpcScalarResult<C>, C:CurveGroup);
 
 impl<C: CurveGroup> MpcPointResult<C> {
-    /// Multiply a batch of `MpcPointResult<C>`s with a batch of `MpcScalarResult`s
+    /// Multiply a batch of `MpcPointResult`s with a batch of `MpcScalarResult`s
     #[allow(non_snake_case)]
     pub fn batch_mul(a: &[MpcScalarResult<C>], b: &[MpcPointResult<C>]) -> Vec<MpcPointResult<C>> {
         assert_eq!(a.len(), b.len(), "Batch add requires equal length inputs");

--- a/src/algebra/mpc_scalar.rs
+++ b/src/algebra/mpc_scalar.rs
@@ -33,7 +33,7 @@ impl<C: CurveGroup> From<ScalarResult<C>> for MpcScalarResult<C> {
     }
 }
 
-/// Defines the result handle type that represents a future result of an `MpcScalarResult<C>`
+/// Defines the result handle type that represents a future result of an `MpcScalar`
 impl<C: CurveGroup> MpcScalarResult<C> {
     /// Creates an MPC scalar from a given underlying scalar assumed to be a secret share
     pub fn new_shared(value: ScalarResult<C>) -> MpcScalarResult<C> {
@@ -199,7 +199,7 @@ impl<C: CurveGroup> Add<&MpcScalarResult<C>> for &MpcScalarResult<C> {
 impl_borrow_variants!(MpcScalarResult<C>, Add, add, +, MpcScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> MpcScalarResult<C> {
-    /// Add two batches of `MpcScalarResult<C>`s using a single batched gate
+    /// Add two batches of `MpcScalarResult`s using a single batched gate
     pub fn batch_add(
         a: &[MpcScalarResult<C>],
         b: &[MpcScalarResult<C>],
@@ -230,7 +230,7 @@ impl<C: CurveGroup> MpcScalarResult<C> {
         scalars.into_iter().map(|s| s.into()).collect_vec()
     }
 
-    /// Add a batch of `MpcScalarResult<C>`s to a batch of public `ScalarResult<C>`s
+    /// Add a batch of `MpcScalarResult`s to a batch of public `ScalarResult`s
     pub fn batch_add_public(
         a: &[MpcScalarResult<C>],
         b: &[ScalarResult<C>],
@@ -364,7 +364,7 @@ impl<C: CurveGroup> Sub<&MpcScalarResult<C>> for &MpcScalarResult<C> {
 impl_borrow_variants!(MpcScalarResult<C>, Sub, sub, -, MpcScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> MpcScalarResult<C> {
-    /// Subtract two batches of `MpcScalarResult<C>`s using a single batched gate
+    /// Subtract two batches of `MpcScalarResult`s using a single batched gate
     pub fn batch_sub(
         a: &[MpcScalarResult<C>],
         b: &[MpcScalarResult<C>],
@@ -400,7 +400,7 @@ impl<C: CurveGroup> MpcScalarResult<C> {
         scalars.into_iter().map(|s| s.into()).collect_vec()
     }
 
-    /// Subtract a batch of `MpcScalarResult<C>`s from a batch of public `ScalarResult<C>`s
+    /// Subtract a batch of `MpcScalarResult`s from a batch of public `ScalarResult`s
     pub fn batch_sub_public(
         a: &[MpcScalarResult<C>],
         b: &[ScalarResult<C>],
@@ -543,7 +543,7 @@ impl<C: CurveGroup> Mul<&MpcScalarResult<C>> for &MpcScalarResult<C> {
 impl_borrow_variants!(MpcScalarResult<C>, Mul, mul, *, MpcScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> MpcScalarResult<C> {
-    /// Multiply a batch of `MpcScalarResult<C>s` over a single network op
+    /// Multiply a batch of `MpcScalarResult`s over a single network op
     pub fn batch_mul(
         a: &[MpcScalarResult<C>],
         b: &[MpcScalarResult<C>],
@@ -578,7 +578,7 @@ impl<C: CurveGroup> MpcScalarResult<C> {
         MpcScalarResult::batch_add(&de_plus_db, &ea_plus_c)
     }
 
-    /// Multiply a batch of `MpcScalarResult<C>`s by a batch of public `ScalarResult<C>`s
+    /// Multiply a batch of `MpcScalarResult`s by a batch of public `ScalarResult`s
     pub fn batch_mul_public(
         a: &[MpcScalarResult<C>],
         b: &[ScalarResult<C>],

--- a/src/algebra/scalar.rs
+++ b/src/algebra/scalar.rs
@@ -1,4 +1,4 @@
-//! Defines the scalar types that form the basis of the Starknet algebra
+//! Defines the scalar types that form the basis of the MPC algebra
 
 // ----------------------------
 // | Scalar Field Definitions |
@@ -143,9 +143,9 @@ impl<'de, C: CurveGroup> Deserialize<'de> for Scalar<C> {
 
 // === Addition === //
 
-/// A type alias for a result that resolves to a `Scalar<C>`
+/// A type alias for a result that resolves to a `Scalar`
 pub type ScalarResult<C> = ResultHandle<C, Scalar<C>>;
-/// A type alias for a result that resolves to a batch of `Scalar<C>`s
+/// A type alias for a result that resolves to a batch of `Scalar`s
 pub type BatchScalarResult<C> = ResultHandle<C, Vec<Scalar<C>>>;
 impl<C: CurveGroup> ScalarResult<C> {
     /// Compute the multiplicative inverse of the scalar in its field
@@ -275,7 +275,7 @@ impl<C: CurveGroup> Sub<&ScalarResult<C>> for &ScalarResult<C> {
 impl_borrow_variants!(ScalarResult<C>, Sub, sub, -, ScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> ScalarResult<C> {
-    /// Subtract two batches of `ScalarResult<C>`s
+    /// Subtract two batches of `ScalarResult`s
     pub fn batch_sub(a: &[ScalarResult<C>], b: &[ScalarResult<C>]) -> Vec<ScalarResult<C>> {
         assert_eq!(a.len(), b.len(), "Batch sub requires equal length inputs");
 
@@ -343,7 +343,7 @@ impl<C: CurveGroup> Mul<&ScalarResult<C>> for &ScalarResult<C> {
 impl_borrow_variants!(ScalarResult<C>, Mul, mul, *, ScalarResult<C>, C: CurveGroup);
 
 impl<C: CurveGroup> ScalarResult<C> {
-    /// Multiply two batches of `ScalarResult<C>`s
+    /// Multiply two batches of `ScalarResult`s
     pub fn batch_mul(a: &[ScalarResult<C>], b: &[ScalarResult<C>]) -> Vec<ScalarResult<C>> {
         assert_eq!(a.len(), b.len(), "Batch mul requires equal length inputs");
 
@@ -385,7 +385,7 @@ impl<C: CurveGroup> Neg for &ScalarResult<C> {
 impl_borrow_variants!(ScalarResult<C>, Neg, neg, -, C: CurveGroup);
 
 impl<C: CurveGroup> ScalarResult<C> {
-    /// Negate a batch of `ScalarResult<C>`s
+    /// Negate a batch of `ScalarResult`s
     pub fn batch_neg(a: &[ScalarResult<C>]) -> Vec<ScalarResult<C>> {
         let n = a.len();
         let fabric = &a[0].fabric;

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -1,4 +1,4 @@
-//! Defines Pedersen commitments over the Stark curve used to commit to a value
+//! Defines Pedersen commitments over the system curve used to commit to a value
 //! before opening it
 
 use ark_ec::CurveGroup;

--- a/src/fabric.rs
+++ b/src/fabric.rs
@@ -540,17 +540,17 @@ impl<C: CurveGroup> MpcFabric<C> {
         (0..n).map(|_| val.clone()).collect_vec()
     }
 
-    /// Get the hardcoded curve identity wire as a raw `StarkPoint`
+    /// Get the hardcoded curve identity wire as a raw `CurvePointResult`
     pub fn curve_identity(&self) -> CurvePointResult<C> {
         ResultHandle::new(self.inner.curve_identity(), self.clone())
     }
 
-    /// Get the hardcoded shared curve identity wire as an `MpcStarkPointResult`
+    /// Get the hardcoded shared curve identity wire as an `MpcPointResult`
     fn curve_identity_shared(&self) -> MpcPointResult<C> {
         MpcPointResult::new_shared(self.curve_identity())
     }
 
-    /// Get the hardcoded curve identity wire as an `AuthenticatedStarkPointResult`
+    /// Get the hardcoded curve identity wire as an `AuthenticatedPointResult`
     ///
     /// Both parties hold the identity point directly in this case
     pub fn curve_identity_authenticated(&self) -> AuthenticatedPointResult<C> {
@@ -633,7 +633,7 @@ impl<C: CurveGroup> MpcFabric<C> {
         AuthenticatedScalarResult::new_shared_from_batch_result(shares, n)
     }
 
-    /// Share a `StarkPoint` value with the counterparty
+    /// Share a `CurvePoint` value with the counterparty
     pub fn share_point(&self, val: CurvePoint<C>, sender: PartyId) -> AuthenticatedPointResult<C> {
         let point: CurvePointResult<C> = if self.party_id() == sender {
             // As mentioned in https://eprint.iacr.org/2009/226.pdf
@@ -657,7 +657,7 @@ impl<C: CurveGroup> MpcFabric<C> {
         AuthenticatedPointResult::new_shared(point)
     }
 
-    /// Share a batch of `StarkPoint`s with the counterparty
+    /// Share a batch of `CurvePoint`s with the counterparty
     pub fn batch_share_point(
         &self,
         vals: Vec<CurvePoint<C>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(incomplete_features)]
 #![feature(inherent_associated_types)]
 
-//! Defines an MPC implementation over the Stark curve that allows for out-of-order execution of
+//! Defines an MPC implementation over the a generic Arkworks curve that allows for out-of-order execution of
 //! the underlying MPC circuit
 
 use std::sync::{Arc, RwLock};
@@ -39,7 +39,7 @@ pub const PARTY0: u64 = 0;
 pub const PARTY1: u64 = 1;
 
 /// Generate a random curve point by multiplying a random scalar with the
-/// Stark curve group generator
+/// curve group generator
 pub fn random_point<C: CurveGroup>() -> CurvePoint<C> {
     let mut rng = thread_rng();
     CurvePoint::generator() * Scalar::random(&mut rng)


### PR DESCRIPTION
### Purpose
This PR cleans up the library after the crate generic refactor is complete. Specifically:
- Updates comments throughout the `algebra` module
- Changes the package name to `ark-mpc` to reflect the generics changes
- Removes unused dependencies

### Testing
- All unit and integration tests pass